### PR TITLE
ir: simplify the specialized metadata node API

### DIFF
--- a/asm/asm_test.go
+++ b/asm/asm_test.go
@@ -36,6 +36,10 @@ func TestParseFile(t *testing.T) {
 		// DIExpression used in named metdata definition.
 		{path: "testdata/diexpression.ll"},
 
+		// Multiple named metadata definitions with the same metadata name should
+		// be merged into one.
+		{path: "testdata/multiple_named_metadata_defs.ll"},
+
 		// frem constant expression.
 		{path: "testdata/expr_frem.ll"},
 

--- a/asm/example_test.go
+++ b/asm/example_test.go
@@ -222,9 +222,10 @@ func Example() {
 	//     Aliases:           nil,
 	//     IFuncs:            nil,
 	//     AttrGroupDefs:     nil,
-	//     NamedMetadataDefs: nil,
-	//     MetadataDefs:      nil,
-	//     UseListOrders:     nil,
-	//     UseListOrderBBs:   nil,
+	//     NamedMetadataDefs: {
+	//     },
+	//     MetadataDefs:    nil,
+	//     UseListOrders:   nil,
+	//     UseListOrderBBs: nil,
 	// }
 }

--- a/asm/generator.go
+++ b/asm/generator.go
@@ -29,13 +29,13 @@ type generator struct {
 // AST to IR representation.
 func newGenerator() *generator {
 	return &generator{
-		m: &ir.Module{},
+		m: ir.NewModule(),
 		old: oldIndex{
 			typeDefs:          make(map[string]*ast.TypeDef),
 			comdatDefs:        make(map[string]*ast.ComdatDef),
 			globals:           make(map[ir.GlobalIdent]ast.LlvmNode),
 			attrGroupDefs:     make(map[int64]*ast.AttrGroupDef),
-			namedMetadataDefs: make(map[string]*ast.NamedMetadataDef),
+			namedMetadataDefs: make(map[string][]*ast.NamedMetadataDef),
 			metadataDefs:      make(map[int64]*ast.MetadataDef),
 		},
 		new: newIndex{
@@ -44,7 +44,7 @@ func newGenerator() *generator {
 			globals:           make(map[ir.GlobalIdent]constant.Constant),
 			attrGroupDefs:     make(map[int64]*ir.AttrGroupDef),
 			namedMetadataDefs: make(map[string]*metadata.NamedDef),
-			metadataDefs:      make(map[int64]*metadata.Def),
+			metadataDefs:      make(map[int64]metadata.Definition),
 		},
 	}
 }
@@ -73,8 +73,8 @@ type oldIndex struct {
 	// attribute group definition.
 	attrGroupDefs map[int64]*ast.AttrGroupDef
 	// namedMetadataDefs maps from metadata name (without '!' prefix) to named
-	// metadata definition.
-	namedMetadataDefs map[string]*ast.NamedMetadataDef
+	// metadata definitions with the same name.
+	namedMetadataDefs map[string][]*ast.NamedMetadataDef
 	// metadataDefs maps from metadata ID (without '!' prefix) to metadata
 	// definition.
 	metadataDefs map[int64]*ast.MetadataDef
@@ -89,9 +89,6 @@ type oldIndex struct {
 	// definitions, indirect symbol definitions, and function declarations and
 	// definitions in their order of occurrence in the input.
 	globalOrder []ir.GlobalIdent
-	// namedMetadataDefOrder records the metadata name of named metadata
-	// definitions in their order of occurrence in the input.
-	namedMetadataDefOrder []string
 }
 
 // newIndex is an index of IR top-level entities.
@@ -120,5 +117,5 @@ type newIndex struct {
 	namedMetadataDefs map[string]*metadata.NamedDef
 	// metadataDefs maps from metadata ID (without '!' prefix) to metadata
 	// definition.
-	metadataDefs map[int64]*metadata.Def
+	metadataDefs map[int64]metadata.Definition
 }

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -629,7 +629,14 @@ func (gen *generator) irDIGlobalVariableExpression(new metadata.SpecializedNode,
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Expr = expr
+			switch expr := expr.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIExpression:
+				md.Expr = expr
+			default:
+				panic(fmt.Errorf("support for metadata DIGlobalVariableExpression expr field type %T not yet implemented", expr))
+			}
 		default:
 			panic(fmt.Errorf("support for DIGlobalVariableExpression field %T not yet implemented", old))
 		}

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -225,7 +225,14 @@ func (gen *generator) irDICompositeType(new metadata.SpecializedNode, old *ast.D
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DICompositeType file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.BaseTypeField:
@@ -307,7 +314,14 @@ func (gen *generator) irDIDerivedType(new metadata.SpecializedNode, old *ast.DID
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DIDerivedType file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.BaseTypeField:
@@ -484,7 +498,14 @@ func (gen *generator) irDIGlobalVariable(new metadata.SpecializedNode, old *ast.
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DIGlobalVariable file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.TypeField:
@@ -587,7 +608,14 @@ func (gen *generator) irDIImportedEntity(new metadata.SpecializedNode, old *ast.
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DIImportedEntity file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.NameField:
@@ -627,7 +655,14 @@ func (gen *generator) irDILabel(new metadata.SpecializedNode, old *ast.DILabel) 
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DILabel file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		default:
@@ -663,7 +698,14 @@ func (gen *generator) irDILexicalBlock(new metadata.SpecializedNode, old *ast.DI
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DILexicalBlock file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.ColumnField:
@@ -702,7 +744,14 @@ func (gen *generator) irDILexicalBlockFile(new metadata.SpecializedNode, old *as
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DILexicalBlockFile file field type %T not yet implemented", file))
+			}
 		case *ast.DiscriminatorIntField:
 			md.Discriminator = uintLit(oldField.Discriminator())
 		default:
@@ -742,7 +791,14 @@ func (gen *generator) irDILocalVariable(new metadata.SpecializedNode, old *ast.D
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DILocalVariable file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.TypeField:
@@ -856,7 +912,14 @@ func (gen *generator) irDIMacroFile(new metadata.SpecializedNode, old *ast.DIMac
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DIMacroFile file field type %T not yet implemented", file))
+			}
 		case *ast.NodesField:
 			nodes, err := gen.irMDField(oldField.Nodes())
 			if err != nil {
@@ -960,7 +1023,14 @@ func (gen *generator) irDIObjCProperty(new metadata.SpecializedNode, old *ast.DI
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DIObjCProperty file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.SetterField:
@@ -1012,7 +1082,14 @@ func (gen *generator) irDISubprogram(new metadata.SpecializedNode, old *ast.DISu
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DISubprogram file field type %T not yet implemented", file))
+			}
 		case *ast.LineField:
 			md.Line = intLit(oldField.Line())
 		case *ast.TypeField:

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -130,7 +130,14 @@ func (gen *generator) irDICompileUnit(new metadata.SpecializedNode, old *ast.DIC
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.File = file
+			switch file := file.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIFile:
+				md.File = file
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit file field type %T not yet implemented", file))
+			}
 		case *ast.ProducerField:
 			md.Producer = stringLit(oldField.Producer())
 		case *ast.IsOptimizedField:

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -304,7 +304,14 @@ func (gen *generator) irDICompositeType(new metadata.SpecializedNode, old *ast.D
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.VtableHolder = vtableHolder
+			switch vtableHolder := vtableHolder.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DICompositeType:
+				md.VtableHolder = vtableHolder
+			default:
+				panic(fmt.Errorf("support for metadata DICompositeType vtableHolder field type %T not yet implemented", vtableHolder))
+			}
 		case *ast.TemplateParamsField:
 			templateParams, err := gen.irMDField(oldField.TemplateParams())
 			if err != nil {

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -1209,7 +1209,14 @@ func (gen *generator) irDISubprogram(new metadata.SpecializedNode, old *ast.DISu
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Unit = unit
+			switch unit := unit.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DICompileUnit:
+				md.Unit = unit
+			default:
+				panic(fmt.Errorf("support for metadata DISubprogram unit field type %T not yet implemented", unit))
+			}
 		case *ast.TemplateParamsField:
 			templateParams, err := gen.irMDField(oldField.TemplateParams())
 			if err != nil {

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -15,60 +15,60 @@ import (
 
 // irSpecializedMDNode returns the IR specialized metadata node corresponding to
 // the given AST specialized metadata node.
-func (gen *generator) irSpecializedMDNode(old ast.SpecializedMDNode) (metadata.SpecializedNode, error) {
+func (gen *generator) irSpecializedMDNode(new metadata.Definition, old ast.SpecializedMDNode) (metadata.SpecializedNode, error) {
 	switch old := old.(type) {
 	case *ast.DIBasicType:
-		return gen.irDIBasicType(old)
+		return gen.irDIBasicType(new, old)
 	case *ast.DICompileUnit:
-		return gen.irDICompileUnit(old)
+		return gen.irDICompileUnit(new, old)
 	case *ast.DICompositeType:
-		return gen.irDICompositeType(old)
+		return gen.irDICompositeType(new, old)
 	case *ast.DIDerivedType:
-		return gen.irDIDerivedType(old)
+		return gen.irDIDerivedType(new, old)
 	case *ast.DIEnumerator:
-		return gen.irDIEnumerator(old)
+		return gen.irDIEnumerator(new, old)
 	case *ast.DIExpression:
-		return gen.irDIExpression(old)
+		return gen.irDIExpression(new, old)
 	case *ast.DIFile:
-		return gen.irDIFile(old)
+		return gen.irDIFile(new, old)
 	case *ast.DIGlobalVariable:
-		return gen.irDIGlobalVariable(old)
+		return gen.irDIGlobalVariable(new, old)
 	case *ast.DIGlobalVariableExpression:
-		return gen.irDIGlobalVariableExpression(old)
+		return gen.irDIGlobalVariableExpression(new, old)
 	case *ast.DIImportedEntity:
-		return gen.irDIImportedEntity(old)
+		return gen.irDIImportedEntity(new, old)
 	case *ast.DILabel:
-		return gen.irDILabel(old)
+		return gen.irDILabel(new, old)
 	case *ast.DILexicalBlock:
-		return gen.irDILexicalBlock(old)
+		return gen.irDILexicalBlock(new, old)
 	case *ast.DILexicalBlockFile:
-		return gen.irDILexicalBlockFile(old)
+		return gen.irDILexicalBlockFile(new, old)
 	case *ast.DILocalVariable:
-		return gen.irDILocalVariable(old)
+		return gen.irDILocalVariable(new, old)
 	case *ast.DILocation:
-		return gen.irDILocation(old)
+		return gen.irDILocation(new, old)
 	case *ast.DIMacro:
-		return gen.irDIMacro(old)
+		return gen.irDIMacro(new, old)
 	case *ast.DIMacroFile:
-		return gen.irDIMacroFile(old)
+		return gen.irDIMacroFile(new, old)
 	case *ast.DIModule:
-		return gen.irDIModule(old)
+		return gen.irDIModule(new, old)
 	case *ast.DINamespace:
-		return gen.irDINamespace(old)
+		return gen.irDINamespace(new, old)
 	case *ast.DIObjCProperty:
-		return gen.irDIObjCProperty(old)
+		return gen.irDIObjCProperty(new, old)
 	case *ast.DISubprogram:
-		return gen.irDISubprogram(old)
+		return gen.irDISubprogram(new, old)
 	case *ast.DISubrange:
-		return gen.irDISubrange(old)
+		return gen.irDISubrange(new, old)
 	case *ast.DISubroutineType:
-		return gen.irDISubroutineType(old)
+		return gen.irDISubroutineType(new, old)
 	case *ast.DITemplateTypeParameter:
-		return gen.irDITemplateTypeParameter(old)
+		return gen.irDITemplateTypeParameter(new, old)
 	case *ast.DITemplateValueParameter:
-		return gen.irDITemplateValueParameter(old)
+		return gen.irDITemplateValueParameter(new, old)
 	case *ast.GenericDINode:
-		return gen.irGenericDINode(old)
+		return gen.irGenericDINode(new, old)
 	default:
 		panic(fmt.Errorf("support for %T not yet implemented", old))
 	}
@@ -77,9 +77,16 @@ func (gen *generator) irSpecializedMDNode(old ast.SpecializedMDNode) (metadata.S
 // --- [ DIBasicType ] ---------------------------------------------------------
 
 // irDIBasicType returns the IR specialized metadata node DIBasicType
-// corresponding to the given AST specialized metadata node DIBasicType.
-func (gen *generator) irDIBasicType(old *ast.DIBasicType) (*metadata.DIBasicType, error) {
-	md := &metadata.DIBasicType{}
+// corresponding to the given AST specialized metadata node DIBasicType. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIBasicType(new metadata.SpecializedNode, old *ast.DIBasicType) (*metadata.DIBasicType, error) {
+	md, ok := new.(*metadata.DIBasicType)
+	if new == nil {
+		md = &metadata.DIBasicType{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIBasicType, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -104,9 +111,16 @@ func (gen *generator) irDIBasicType(old *ast.DIBasicType) (*metadata.DIBasicType
 // --- [ DICompileUnit ] -------------------------------------------------------
 
 // irDICompileUnit returns the IR specialized metadata node DICompileUnit
-// corresponding to the given AST specialized metadata node DICompileUnit.
-func (gen *generator) irDICompileUnit(old *ast.DICompileUnit) (*metadata.DICompileUnit, error) {
-	md := &metadata.DICompileUnit{}
+// corresponding to the given AST specialized metadata node DICompileUnit. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDICompileUnit(new metadata.SpecializedNode, old *ast.DICompileUnit) (*metadata.DICompileUnit, error) {
+	md, ok := new.(*metadata.DICompileUnit)
+	if new == nil {
+		md = &metadata.DICompileUnit{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DICompileUnit, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.LanguageField:
@@ -177,9 +191,16 @@ func (gen *generator) irDICompileUnit(old *ast.DICompileUnit) (*metadata.DICompi
 // --- [ DICompositeType ] -----------------------------------------------------
 
 // irDICompositeType returns the IR specialized metadata node DICompositeType
-// corresponding to the given AST specialized metadata node DICompositeType.
-func (gen *generator) irDICompositeType(old *ast.DICompositeType) (*metadata.DICompositeType, error) {
-	md := &metadata.DICompositeType{}
+// corresponding to the given AST specialized metadata node DICompositeType. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDICompositeType(new metadata.SpecializedNode, old *ast.DICompositeType) (*metadata.DICompositeType, error) {
+	md, ok := new.(*metadata.DICompositeType)
+	if new == nil {
+		md = &metadata.DICompositeType{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DICompositeType, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -252,9 +273,16 @@ func (gen *generator) irDICompositeType(old *ast.DICompositeType) (*metadata.DIC
 // --- [ DIDerivedType ] -------------------------------------------------------
 
 // irDIDerivedType returns the IR specialized metadata node DIDerivedType
-// corresponding to the given AST specialized metadata node DIDerivedType.
-func (gen *generator) irDIDerivedType(old *ast.DIDerivedType) (*metadata.DIDerivedType, error) {
-	md := &metadata.DIDerivedType{}
+// corresponding to the given AST specialized metadata node DIDerivedType. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIDerivedType(new metadata.SpecializedNode, old *ast.DIDerivedType) (*metadata.DIDerivedType, error) {
+	md, ok := new.(*metadata.DIDerivedType)
+	if new == nil {
+		md = &metadata.DIDerivedType{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIDerivedType, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -308,9 +336,16 @@ func (gen *generator) irDIDerivedType(old *ast.DIDerivedType) (*metadata.DIDeriv
 // --- [ DIEnumerator ] --------------------------------------------------------
 
 // irDIEnumerator returns the IR specialized metadata node DIEnumerator
-// corresponding to the given AST specialized metadata node DIEnumerator.
-func (gen *generator) irDIEnumerator(old *ast.DIEnumerator) (*metadata.DIEnumerator, error) {
-	md := &metadata.DIEnumerator{}
+// corresponding to the given AST specialized metadata node DIEnumerator. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIEnumerator(new metadata.SpecializedNode, old *ast.DIEnumerator) (*metadata.DIEnumerator, error) {
+	md, ok := new.(*metadata.DIEnumerator)
+	if new == nil {
+		md = &metadata.DIEnumerator{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIEnumerator, got %T", new))
+	}
 	isUnsigned := false
 	for _, oldField := range old.Fields() {
 		if oldField, ok := oldField.(*ast.IsUnsignedField); ok {
@@ -345,9 +380,16 @@ func (gen *generator) irDIEnumerator(old *ast.DIEnumerator) (*metadata.DIEnumera
 // --- [ DIExpression ] --------------------------------------------------------
 
 // irDIExpression returns the IR specialized metadata node DIExpression
-// corresponding to the given AST specialized metadata node DIExpression.
-func (gen *generator) irDIExpression(old *ast.DIExpression) (*metadata.DIExpression, error) {
-	md := &metadata.DIExpression{}
+// corresponding to the given AST specialized metadata node DIExpression. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIExpression(new metadata.SpecializedNode, old *ast.DIExpression) (*metadata.DIExpression, error) {
+	md, ok := new.(*metadata.DIExpression)
+	if new == nil {
+		md = &metadata.DIExpression{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIExpression, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		field, err := gen.irDIExpressionField(oldField)
 		if err != nil {
@@ -360,6 +402,8 @@ func (gen *generator) irDIExpression(old *ast.DIExpression) (*metadata.DIExpress
 
 // ~~~ [ DIExpressionField ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+// irDIExpressionField returns the IR DIExpression field corresponding to the
+// given AST DIExpression field.
 func (gen *generator) irDIExpressionField(old ast.DIExpressionField) (metadata.DIExpressionField, error) {
 	switch old := old.(type) {
 	case *ast.UintLit:
@@ -374,9 +418,16 @@ func (gen *generator) irDIExpressionField(old ast.DIExpressionField) (metadata.D
 // --- [ DIFile ] --------------------------------------------------------------
 
 // irDIFile returns the IR specialized metadata node DIFile corresponding to the
-// given AST specialized metadata node DIFile.
-func (gen *generator) irDIFile(old *ast.DIFile) (*metadata.DIFile, error) {
-	md := &metadata.DIFile{}
+// given AST specialized metadata node DIFile. A new IR specialized metadata
+// node correspoding to the AST specialized metadata node is created if new is
+// nil, otherwise the body of new is populated.
+func (gen *generator) irDIFile(new metadata.SpecializedNode, old *ast.DIFile) (*metadata.DIFile, error) {
+	md, ok := new.(*metadata.DIFile)
+	if new == nil {
+		md = &metadata.DIFile{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIFile, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.FilenameField:
@@ -399,9 +450,16 @@ func (gen *generator) irDIFile(old *ast.DIFile) (*metadata.DIFile, error) {
 // --- [ DIGlobalVariable ] ----------------------------------------------------
 
 // irDIGlobalVariable returns the IR specialized metadata node DIGlobalVariable
-// corresponding to the given AST specialized metadata node DIGlobalVariable.
-func (gen *generator) irDIGlobalVariable(old *ast.DIGlobalVariable) (*metadata.DIGlobalVariable, error) {
-	md := &metadata.DIGlobalVariable{}
+// corresponding to the given AST specialized metadata node DIGlobalVariable. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIGlobalVariable(new metadata.SpecializedNode, old *ast.DIGlobalVariable) (*metadata.DIGlobalVariable, error) {
+	md, ok := new.(*metadata.DIGlobalVariable)
+	if new == nil {
+		md = &metadata.DIGlobalVariable{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIGlobalVariable, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.NameField:
@@ -457,9 +515,16 @@ func (gen *generator) irDIGlobalVariable(old *ast.DIGlobalVariable) (*metadata.D
 
 // irDIGlobalVariableExpression returns the IR specialized metadata node
 // DIGlobalVariableExpression corresponding to the given AST specialized
-// metadata node DIGlobalVariableExpression.
-func (gen *generator) irDIGlobalVariableExpression(old *ast.DIGlobalVariableExpression) (*metadata.DIGlobalVariableExpression, error) {
-	md := &metadata.DIGlobalVariableExpression{}
+// metadata node DIGlobalVariableExpression. A new IR specialized metadata node
+// correspoding to the AST specialized metadata node is created if new is nil,
+// otherwise the body of new is populated.
+func (gen *generator) irDIGlobalVariableExpression(new metadata.SpecializedNode, old *ast.DIGlobalVariableExpression) (*metadata.DIGlobalVariableExpression, error) {
+	md, ok := new.(*metadata.DIGlobalVariableExpression)
+	if new == nil {
+		md = &metadata.DIGlobalVariableExpression{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIGlobalVariableExpression, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.VarField:
@@ -484,9 +549,16 @@ func (gen *generator) irDIGlobalVariableExpression(old *ast.DIGlobalVariableExpr
 // --- [ DIImportedEntity ] ----------------------------------------------------
 
 // irDIImportedEntity returns the IR specialized metadata node DIImportedEntity
-// corresponding to the given AST specialized metadata node DIImportedEntity.
-func (gen *generator) irDIImportedEntity(old *ast.DIImportedEntity) (*metadata.DIImportedEntity, error) {
-	md := &metadata.DIImportedEntity{}
+// corresponding to the given AST specialized metadata node DIImportedEntity. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIImportedEntity(new metadata.SpecializedNode, old *ast.DIImportedEntity) (*metadata.DIImportedEntity, error) {
+	md, ok := new.(*metadata.DIImportedEntity)
+	if new == nil {
+		md = &metadata.DIImportedEntity{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIImportedEntity, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -523,9 +595,16 @@ func (gen *generator) irDIImportedEntity(old *ast.DIImportedEntity) (*metadata.D
 // --- [ DILabel ] -------------------------------------------------------------
 
 // irDILabel returns the IR specialized metadata node DILabel corresponding to
-// the given AST specialized metadata node DILabel.
-func (gen *generator) irDILabel(old *ast.DILabel) (*metadata.DILabel, error) {
-	md := &metadata.DILabel{}
+// the given AST specialized metadata node DILabel. A new IR specialized
+// metadata node correspoding to the AST specialized metadata node is created if
+// new is nil, otherwise the body of new is populated.
+func (gen *generator) irDILabel(new metadata.SpecializedNode, old *ast.DILabel) (*metadata.DILabel, error) {
+	md, ok := new.(*metadata.DILabel)
+	if new == nil {
+		md = &metadata.DILabel{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DILabel, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -554,9 +633,16 @@ func (gen *generator) irDILabel(old *ast.DILabel) (*metadata.DILabel, error) {
 // --- [ DILexicalBlock ] ------------------------------------------------------
 
 // irDILexicalBlock returns the IR specialized metadata node DILexicalBlock
-// corresponding to the given AST specialized metadata node DILexicalBlock.
-func (gen *generator) irDILexicalBlock(old *ast.DILexicalBlock) (*metadata.DILexicalBlock, error) {
-	md := &metadata.DILexicalBlock{}
+// corresponding to the given AST specialized metadata node DILexicalBlock. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDILexicalBlock(new metadata.SpecializedNode, old *ast.DILexicalBlock) (*metadata.DILexicalBlock, error) {
+	md, ok := new.(*metadata.DILexicalBlock)
+	if new == nil {
+		md = &metadata.DILexicalBlock{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DILexicalBlock, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -586,9 +672,16 @@ func (gen *generator) irDILexicalBlock(old *ast.DILexicalBlock) (*metadata.DILex
 
 // irDILexicalBlockFile returns the IR specialized metadata node
 // DILexicalBlockFile corresponding to the given AST specialized metadata node
-// DILexicalBlockFile.
-func (gen *generator) irDILexicalBlockFile(old *ast.DILexicalBlockFile) (*metadata.DILexicalBlockFile, error) {
-	md := &metadata.DILexicalBlockFile{}
+// DILexicalBlockFile. A new IR specialized metadata node correspoding to the
+// AST specialized metadata node is created if new is nil, otherwise the body of
+// new is populated.
+func (gen *generator) irDILexicalBlockFile(new metadata.SpecializedNode, old *ast.DILexicalBlockFile) (*metadata.DILexicalBlockFile, error) {
+	md, ok := new.(*metadata.DILexicalBlockFile)
+	if new == nil {
+		md = &metadata.DILexicalBlockFile{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DILexicalBlockFile, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -615,9 +708,16 @@ func (gen *generator) irDILexicalBlockFile(old *ast.DILexicalBlockFile) (*metada
 // --- [ DILocalVariable ] -----------------------------------------------------
 
 // irDILocalVariable returns the IR specialized metadata node DILocalVariable
-// corresponding to the given AST specialized metadata node DILocalVariable.
-func (gen *generator) irDILocalVariable(old *ast.DILocalVariable) (*metadata.DILocalVariable, error) {
-	md := &metadata.DILocalVariable{}
+// corresponding to the given AST specialized metadata node DILocalVariable. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDILocalVariable(new metadata.SpecializedNode, old *ast.DILocalVariable) (*metadata.DILocalVariable, error) {
+	md, ok := new.(*metadata.DILocalVariable)
+	if new == nil {
+		md = &metadata.DILocalVariable{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DILocalVariable, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.NameField:
@@ -658,9 +758,16 @@ func (gen *generator) irDILocalVariable(old *ast.DILocalVariable) (*metadata.DIL
 // --- [ DILocation ] ----------------------------------------------------------
 
 // irDILocation returns the IR specialized metadata node DILocation
-// corresponding to the given AST specialized metadata node DILocation.
-func (gen *generator) irDILocation(old *ast.DILocation) (*metadata.DILocation, error) {
-	md := &metadata.DILocation{}
+// corresponding to the given AST specialized metadata node DILocation. A new IR
+// specialized metadata node correspoding to the AST specialized metadata node
+// is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDILocation(new metadata.SpecializedNode, old *ast.DILocation) (*metadata.DILocation, error) {
+	md, ok := new.(*metadata.DILocation)
+	if new == nil {
+		md = &metadata.DILocation{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DILocation, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.LineField:
@@ -691,9 +798,16 @@ func (gen *generator) irDILocation(old *ast.DILocation) (*metadata.DILocation, e
 // --- [ DIMacro ] -------------------------------------------------------------
 
 // irDIMacro returns the IR specialized metadata node DIMacro corresponding to
-// the given AST specialized metadata node DIMacro.
-func (gen *generator) irDIMacro(old *ast.DIMacro) (*metadata.DIMacro, error) {
-	md := &metadata.DIMacro{}
+// the given AST specialized metadata node DIMacro. A new IR specialized
+// metadata node correspoding to the AST specialized metadata node is created if
+// new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIMacro(new metadata.SpecializedNode, old *ast.DIMacro) (*metadata.DIMacro, error) {
+	md, ok := new.(*metadata.DIMacro)
+	if new == nil {
+		md = &metadata.DIMacro{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIMacro, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TypeMacinfoField:
@@ -714,9 +828,16 @@ func (gen *generator) irDIMacro(old *ast.DIMacro) (*metadata.DIMacro, error) {
 // --- [ DIMacroFile ] ---------------------------------------------------------
 
 // irDIMacroFile returns the IR specialized metadata node DIMacroFile
-// corresponding to the given AST specialized metadata node DIMacroFile.
-func (gen *generator) irDIMacroFile(old *ast.DIMacroFile) (*metadata.DIMacroFile, error) {
-	md := &metadata.DIMacroFile{}
+// corresponding to the given AST specialized metadata node DIMacroFile. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIMacroFile(new metadata.SpecializedNode, old *ast.DIMacroFile) (*metadata.DIMacroFile, error) {
+	md, ok := new.(*metadata.DIMacroFile)
+	if new == nil {
+		md = &metadata.DIMacroFile{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIMacroFile, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TypeMacinfoField:
@@ -745,9 +866,16 @@ func (gen *generator) irDIMacroFile(old *ast.DIMacroFile) (*metadata.DIMacroFile
 // --- [ DIModule ] ------------------------------------------------------------
 
 // irDIModule returns the IR specialized metadata node DIModule corresponding to
-// the given AST specialized metadata node DIModule.
-func (gen *generator) irDIModule(old *ast.DIModule) (*metadata.DIModule, error) {
-	md := &metadata.DIModule{}
+// the given AST specialized metadata node DIModule. A new IR specialized
+// metadata node correspoding to the AST specialized metadata node is created if
+// new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIModule(new metadata.SpecializedNode, old *ast.DIModule) (*metadata.DIModule, error) {
+	md, ok := new.(*metadata.DIModule)
+	if new == nil {
+		md = &metadata.DIModule{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIModule, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -774,9 +902,16 @@ func (gen *generator) irDIModule(old *ast.DIModule) (*metadata.DIModule, error) 
 // --- [ DINamespace ] ---------------------------------------------------------
 
 // irDINamespace returns the IR specialized metadata node DINamespace
-// corresponding to the given AST specialized metadata node DINamespace.
-func (gen *generator) irDINamespace(old *ast.DINamespace) (*metadata.DINamespace, error) {
-	md := &metadata.DINamespace{}
+// corresponding to the given AST specialized metadata node DINamespace. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDINamespace(new metadata.SpecializedNode, old *ast.DINamespace) (*metadata.DINamespace, error) {
+	md, ok := new.(*metadata.DINamespace)
+	if new == nil {
+		md = &metadata.DINamespace{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DINamespace, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -799,9 +934,16 @@ func (gen *generator) irDINamespace(old *ast.DINamespace) (*metadata.DINamespace
 // --- [ DIObjCProperty ] ------------------------------------------------------
 
 // irDIObjCProperty returns the IR specialized metadata node DIObjCProperty
-// corresponding to the given AST specialized metadata node DIObjCProperty.
-func (gen *generator) irDIObjCProperty(old *ast.DIObjCProperty) (*metadata.DIObjCProperty, error) {
-	md := &metadata.DIObjCProperty{}
+// corresponding to the given AST specialized metadata node DIObjCProperty. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDIObjCProperty(new metadata.SpecializedNode, old *ast.DIObjCProperty) (*metadata.DIObjCProperty, error) {
+	md, ok := new.(*metadata.DIObjCProperty)
+	if new == nil {
+		md = &metadata.DIObjCProperty{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DIObjCProperty, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.NameField:
@@ -836,9 +978,16 @@ func (gen *generator) irDIObjCProperty(old *ast.DIObjCProperty) (*metadata.DIObj
 // --- [ DISubprogram ] --------------------------------------------------------
 
 // irDISubprogram returns the IR specialized metadata node DISubprogram
-// corresponding to the given AST specialized metadata node DISubprogram.
-func (gen *generator) irDISubprogram(old *ast.DISubprogram) (*metadata.DISubprogram, error) {
-	md := &metadata.DISubprogram{}
+// corresponding to the given AST specialized metadata node DISubprogram. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDISubprogram(new metadata.SpecializedNode, old *ast.DISubprogram) (*metadata.DISubprogram, error) {
+	md, ok := new.(*metadata.DISubprogram)
+	if new == nil {
+		md = &metadata.DISubprogram{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DISubprogram, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.ScopeField:
@@ -927,9 +1076,16 @@ func (gen *generator) irDISubprogram(old *ast.DISubprogram) (*metadata.DISubprog
 // --- [ DISubrange ] ----------------------------------------------------------
 
 // irDISubrange returns the IR specialized metadata node DISubrange
-// corresponding to the given AST specialized metadata node DISubrange.
-func (gen *generator) irDISubrange(old *ast.DISubrange) (*metadata.DISubrange, error) {
-	md := &metadata.DISubrange{}
+// corresponding to the given AST specialized metadata node DISubrange. A new IR
+// specialized metadata node correspoding to the AST specialized metadata node
+// is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDISubrange(new metadata.SpecializedNode, old *ast.DISubrange) (*metadata.DISubrange, error) {
+	md, ok := new.(*metadata.DISubrange)
+	if new == nil {
+		md = &metadata.DISubrange{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DISubrange, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.CountField:
@@ -950,9 +1106,16 @@ func (gen *generator) irDISubrange(old *ast.DISubrange) (*metadata.DISubrange, e
 // --- [ DISubroutineType ] ----------------------------------------------------
 
 // irDISubroutineType returns the IR specialized metadata node DISubroutineType
-// corresponding to the given AST specialized metadata node DISubroutineType.
-func (gen *generator) irDISubroutineType(old *ast.DISubroutineType) (*metadata.DISubroutineType, error) {
-	md := &metadata.DISubroutineType{}
+// corresponding to the given AST specialized metadata node DISubroutineType. A
+// new IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irDISubroutineType(new metadata.SpecializedNode, old *ast.DISubroutineType) (*metadata.DISubroutineType, error) {
+	md, ok := new.(*metadata.DISubroutineType)
+	if new == nil {
+		md = &metadata.DISubroutineType{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DISubroutineType, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.FlagsField:
@@ -976,9 +1139,16 @@ func (gen *generator) irDISubroutineType(old *ast.DISubroutineType) (*metadata.D
 
 // irDITemplateTypeParameter returns the IR specialized metadata node
 // DITemplateTypeParameter corresponding to the given AST specialized metadata
-// node DITemplateTypeParameter.
-func (gen *generator) irDITemplateTypeParameter(old *ast.DITemplateTypeParameter) (*metadata.DITemplateTypeParameter, error) {
-	md := &metadata.DITemplateTypeParameter{}
+// node DITemplateTypeParameter. A new IR specialized metadata node correspoding
+// to the AST specialized metadata node is created if new is nil, otherwise the
+// body of new is populated.
+func (gen *generator) irDITemplateTypeParameter(new metadata.SpecializedNode, old *ast.DITemplateTypeParameter) (*metadata.DITemplateTypeParameter, error) {
+	md, ok := new.(*metadata.DITemplateTypeParameter)
+	if new == nil {
+		md = &metadata.DITemplateTypeParameter{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DITemplateTypeParameter, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.NameField:
@@ -1000,9 +1170,16 @@ func (gen *generator) irDITemplateTypeParameter(old *ast.DITemplateTypeParameter
 
 // irDITemplateValueParameter returns the IR specialized metadata node
 // DITemplateValueParameter corresponding to the given AST specialized metadata
-// node DITemplateValueParameter.
-func (gen *generator) irDITemplateValueParameter(old *ast.DITemplateValueParameter) (*metadata.DITemplateValueParameter, error) {
-	md := &metadata.DITemplateValueParameter{}
+// node DITemplateValueParameter. A new IR specialized metadata node
+// correspoding to the AST specialized metadata node is created if new is nil,
+// otherwise the body of new is populated.
+func (gen *generator) irDITemplateValueParameter(new metadata.SpecializedNode, old *ast.DITemplateValueParameter) (*metadata.DITemplateValueParameter, error) {
+	md, ok := new.(*metadata.DITemplateValueParameter)
+	if new == nil {
+		md = &metadata.DITemplateValueParameter{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.DITemplateValueParameter, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -1031,9 +1208,16 @@ func (gen *generator) irDITemplateValueParameter(old *ast.DITemplateValueParamet
 // --- [ GenericDINode ] -------------------------------------------------------
 
 // irGenericDINode returns the IR specialized metadata node GenericDINode
-// corresponding to the given AST specialized metadata node GenericDINode.
-func (gen *generator) irGenericDINode(old *ast.GenericDINode) (*metadata.GenericDINode, error) {
-	md := &metadata.GenericDINode{}
+// corresponding to the given AST specialized metadata node GenericDINode. A new
+// IR specialized metadata node correspoding to the AST specialized metadata
+// node is created if new is nil, otherwise the body of new is populated.
+func (gen *generator) irGenericDINode(new metadata.SpecializedNode, old *ast.GenericDINode) (*metadata.GenericDINode, error) {
+	md, ok := new.(*metadata.GenericDINode)
+	if new == nil {
+		md = &metadata.GenericDINode{MetadataID: -1}
+	} else if !ok {
+		panic(fmt.Errorf("invalid IR specialized metadata node for AST specialized metadata node; expected *metadata.GenericDINode, got %T", new))
+	}
 	for _, oldField := range old.Fields() {
 		switch oldField := oldField.(type) {
 		case *ast.TagField:
@@ -1041,7 +1225,7 @@ func (gen *generator) irGenericDINode(old *ast.GenericDINode) (*metadata.Generic
 		case *ast.HeaderField:
 			md.Header = stringLit(oldField.Header())
 		case *ast.OperandsField:
-			for _, field := range oldField.Operands().MDFields() {
+			for _, field := range oldField.Operands() {
 				operand, err := gen.irMDField(field)
 				if err != nil {
 					return nil, errors.WithStack(err)

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -623,7 +623,14 @@ func (gen *generator) irDIGlobalVariableExpression(new metadata.SpecializedNode,
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Var = v
+			switch v := v.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DIGlobalVariable:
+				md.Var = v
+			default:
+				panic(fmt.Errorf("support for metadata DIGlobalVariableExpression var field type %T not yet implemented", v))
+			}
 		case *ast.ExprField:
 			expr, err := gen.irMDField(oldField.Expr())
 			if err != nil {

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -179,7 +179,15 @@ func (gen *generator) irDICompileUnit(new metadata.SpecializedNode, old *ast.DIC
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Macros = macros
+			switch macros := macros.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Macros = macros
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit macros field type %T not yet implemented", macros))
+			}
+
 		case *ast.DwoIdField:
 			md.DwoID = uintLit(oldField.DwoId())
 		case *ast.SplitDebugInliningField:

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -155,25 +155,53 @@ func (gen *generator) irDICompileUnit(new metadata.SpecializedNode, old *ast.DIC
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Enums = enums
+			switch enums := enums.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Enums = enums
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit enums field type %T not yet implemented", enums))
+			}
 		case *ast.RetainedTypesField:
 			retainedTypes, err := gen.irMDField(oldField.RetainedTypes())
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.RetainedTypes = retainedTypes
+			switch retainedTypes := retainedTypes.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.RetainedTypes = retainedTypes
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit retainedTypes field type %T not yet implemented", retainedTypes))
+			}
 		case *ast.GlobalsField:
 			globals, err := gen.irMDField(oldField.Globals())
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Globals = globals
+			switch globals := globals.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Globals = globals
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit globals field type %T not yet implemented", globals))
+			}
 		case *ast.ImportsField:
 			imports, err := gen.irMDField(oldField.Imports())
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Imports = imports
+			switch imports := imports.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Imports = imports
+			default:
+				panic(fmt.Errorf("support for metadata DICompileUnit imports field type %T not yet implemented", imports))
+			}
 		case *ast.MacrosField:
 			macros, err := gen.irMDField(oldField.Macros())
 			if err != nil {

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -303,7 +303,14 @@ func (gen *generator) irDICompositeType(new metadata.SpecializedNode, old *ast.D
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.TemplateParams = templateParams
+			switch templateParams := templateParams.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.TemplateParams = templateParams
+			default:
+				panic(fmt.Errorf("support for metadata DICompositeType templateParams field type %T not yet implemented", templateParams))
+			}
 		case *ast.IdentifierField:
 			md.Identifier = stringLit(oldField.Identifier())
 		case *ast.DiscriminatorField:
@@ -558,7 +565,14 @@ func (gen *generator) irDIGlobalVariable(new metadata.SpecializedNode, old *ast.
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.TemplateParams = templateParams
+			switch templateParams := templateParams.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.TemplateParams = templateParams
+			default:
+				panic(fmt.Errorf("support for metadata DIGlobalVariable templateParams field type %T not yet implemented", templateParams))
+			}
 		case *ast.DeclarationField:
 			declaration, err := gen.irMDField(oldField.Declaration())
 			if err != nil {
@@ -1173,7 +1187,14 @@ func (gen *generator) irDISubprogram(new metadata.SpecializedNode, old *ast.DISu
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.TemplateParams = templateParams
+			switch templateParams := templateParams.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.TemplateParams = templateParams
+			default:
+				panic(fmt.Errorf("support for metadata DISubprogram templateParams field type %T not yet implemented", templateParams))
+			}
 		case *ast.DeclarationField:
 			declaration, err := gen.irMDField(oldField.Declaration())
 			if err != nil {

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -1213,13 +1213,27 @@ func (gen *generator) irDISubprogram(new metadata.SpecializedNode, old *ast.DISu
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.RetainedNodes = retainedNodes
+			switch retainedNodes := retainedNodes.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.RetainedNodes = retainedNodes
+			default:
+				panic(fmt.Errorf("support for metadata DISubprogram retainedNodes field type %T not yet implemented", retainedNodes))
+			}
 		case *ast.ThrownTypesField:
 			thrownTypes, err := gen.irMDField(oldField.ThrownTypes())
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.ThrownTypes = thrownTypes
+			switch thrownTypes := thrownTypes.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.ThrownTypes = thrownTypes
+			default:
+				panic(fmt.Errorf("support for metadata DISubprogram thrownTypes field type %T not yet implemented", thrownTypes))
+			}
 		default:
 			panic(fmt.Errorf("support for DISubprogram field %T not yet implemented", old))
 		}
@@ -1281,7 +1295,14 @@ func (gen *generator) irDISubroutineType(new metadata.SpecializedNode, old *ast.
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Types = ts
+			switch ts := ts.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Types = ts
+			default:
+				panic(fmt.Errorf("support for metadata DISubroutineType types field type %T not yet implemented", ts))
+			}
 		default:
 			panic(fmt.Errorf("support for DISubroutineType field %T not yet implemented", old))
 		}

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -187,7 +187,6 @@ func (gen *generator) irDICompileUnit(new metadata.SpecializedNode, old *ast.DIC
 			default:
 				panic(fmt.Errorf("support for metadata DICompileUnit macros field type %T not yet implemented", macros))
 			}
-
 		case *ast.DwoIdField:
 			md.DwoID = uintLit(oldField.DwoId())
 		case *ast.SplitDebugInliningField:
@@ -933,7 +932,14 @@ func (gen *generator) irDIMacroFile(new metadata.SpecializedNode, old *ast.DIMac
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Nodes = nodes
+			switch nodes := nodes.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Nodes = nodes
+			default:
+				panic(fmt.Errorf("support for metadata DIMacroFile nodes field type %T not yet implemented", nodes))
+			}
 		default:
 			panic(fmt.Errorf("support for DIMacroFile field %T not yet implemented", old))
 		}

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -918,7 +918,14 @@ func (gen *generator) irDILocation(new metadata.SpecializedNode, old *ast.DILoca
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.InlinedAt = inlinedAt
+			switch inlinedAt := inlinedAt.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.DILocation:
+				md.InlinedAt = inlinedAt
+			default:
+				panic(fmt.Errorf("support for metadata DILocation inlinedAt field type %T not yet implemented", inlinedAt))
+			}
 		case *ast.IsImplicitCodeField:
 			md.IsImplicitCode = boolLit(oldField.IsImplicitCode())
 		default:

--- a/asm/specialized_metadata.go
+++ b/asm/specialized_metadata.go
@@ -289,7 +289,14 @@ func (gen *generator) irDICompositeType(new metadata.SpecializedNode, old *ast.D
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			md.Elements = elements
+			switch elements := elements.(type) {
+			case *metadata.NullLit:
+				// nothing to do.
+			case *metadata.Tuple:
+				md.Elements = elements
+			default:
+				panic(fmt.Errorf("support for metadata DICompositeType elements field type %T not yet implemented", elements))
+			}
 		case *ast.RuntimeLangField:
 			md.RuntimeLang = irDwarfLang(oldField.RuntimeLang())
 		case *ast.VtableHolderField:

--- a/asm/testdata/diexpression.ll
+++ b/asm/testdata/diexpression.ll
@@ -1,3 +1,3 @@
-!foo = !{!DIExpression()}
 !bar = !{!DIExpression(42)}
 !baz = !{!DIExpression(42, DW_OP_addr)}
+!foo = !{!DIExpression()}

--- a/asm/testdata/multiple_named_metadata_defs.ll
+++ b/asm/testdata/multiple_named_metadata_defs.ll
@@ -1,0 +1,2 @@
+!foo = !{!DIExpression(1)}
+!foo = !{!DIExpression(2)}

--- a/asm/testdata/multiple_named_metadata_defs.ll.golden
+++ b/asm/testdata/multiple_named_metadata_defs.ll.golden
@@ -1,0 +1,1 @@
+!foo = !{!DIExpression(1), !DIExpression(2)}

--- a/asm/translate.go
+++ b/asm/translate.go
@@ -76,8 +76,7 @@
 //
 //    d) Add IR attribute group definitions to the IR module in numeric order.
 //
-//    e) Add IR named metadata definitions to the IR module in order of
-//       occurrence in the input.
+//    e) Add IR named metadata definitions to the IR module.
 //
 //    f) Add IR metadata definitions to the IR module in numeric order.
 
@@ -178,8 +177,7 @@ func (gen *generator) addDefsToModule() {
 	gen.addGlobalEntitiesToModule()
 	// 8d. Add IR attribute group definitions to the IR module in numeric order.
 	gen.addAttrGroupDefsToModule()
-	// 8e. Add IR named metadata definitions to the IR module in order of
-	//     occurrence in the input.
+	// 8e. Add IR named metadata definitions to the IR module.
 	gen.addNamedMetadataDefsToModule()
 	// 8f. Add IR metadata definitions to the IR module in numeric order.
 	gen.addMetadataDefsToModule()
@@ -279,19 +277,11 @@ func (gen *generator) addAttrGroupDefsToModule() {
 }
 
 // addNamedMetadataDefsToModule adds IR named metadata definitions to the IR
-// module in order of occurrence in the input.
+// module.
 func (gen *generator) addNamedMetadataDefsToModule() {
-	// 8e. Add IR named metadata definitions to the IR module in order of
-	//     occurrence in the input.
-	if len(gen.old.namedMetadataDefOrder) > 0 {
-		gen.m.NamedMetadataDefs = make([]*metadata.NamedDef, len(gen.old.namedMetadataDefOrder))
-		for i, name := range gen.old.namedMetadataDefOrder {
-			def, ok := gen.new.namedMetadataDefs[name]
-			if !ok {
-				panic(fmt.Errorf("unable to locate metadata name %q", enc.MetadataName(name)))
-			}
-			gen.m.NamedMetadataDefs[i] = def
-		}
+	// 8e. Add IR named metadata definitions to the IR module.
+	for name, def := range gen.new.namedMetadataDefs {
+		gen.m.NamedMetadataDefs[name] = def
 	}
 }
 
@@ -307,7 +297,7 @@ func (gen *generator) addMetadataDefsToModule() {
 	}
 	sort.Slice(metadataIDs, less)
 	if len(metadataIDs) > 0 {
-		gen.m.MetadataDefs = make([]*metadata.Def, len(metadataIDs))
+		gen.m.MetadataDefs = make([]metadata.Definition, len(metadataIDs))
 		for i, id := range metadataIDs {
 			def, ok := gen.new.metadataDefs[id]
 			if !ok {

--- a/ir/metadata/metadata.go
+++ b/ir/metadata/metadata.go
@@ -49,38 +49,6 @@ func (md *NamedDef) LLString() string {
 	return buf.String()
 }
 
-// ~~~ [ Metadata definition ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-// TODO: check if metadata.Def should implement value.Value.
-
-// Def is a metadata definition.
-type Def struct {
-	// Metadata definition ID (without '!' prefix).
-	MetadataID
-	// Metadata definition node.
-	Node MDNode // Tuple or SpecializedNode
-
-	// extra.
-
-	// (optional) Distinct.
-	Distinct bool
-}
-
-// String returns the LLVM syntax representation of the metadata definition.
-func (md *Def) String() string {
-	return md.Ident()
-}
-
-// LLString returns the LLVM syntax representation of the metadata definition.
-func (md *Def) LLString() string {
-	buf := &strings.Builder{}
-	if md.Distinct {
-		buf.WriteString("distinct ")
-	}
-	buf.WriteString(md.Node.Ident())
-	return buf.String()
-}
-
 // === [ Metadata nodes and metadata strings ] =================================
 
 // --- [ Metadata tuple ] ------------------------------------------------------
@@ -89,6 +57,8 @@ func (md *Def) LLString() string {
 type Tuple struct {
 	// Metadata ID associated with the metadata tuple; -1 if not present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	// Metadata tuple fields.
 	Fields []Field
@@ -101,6 +71,10 @@ func (md *Tuple) String() string {
 
 // Ident returns the identifier associated with the metadata tuple.
 func (md *Tuple) Ident() string {
+	// TODO: tuple field ever null?
+	//if md == nil {
+	//	return "null"
+	//}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -111,6 +85,9 @@ func (md *Tuple) Ident() string {
 func (md *Tuple) LLString() string {
 	// '!' MDFields
 	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	buf.WriteString("!{")
 	for i, field := range md.Fields {
 		if i != 0 {
@@ -120,6 +97,11 @@ func (md *Tuple) LLString() string {
 	}
 	buf.WriteString("}")
 	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *Tuple) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // --- [ Metadata value ] ------------------------------------------------------

--- a/ir/metadata/metadata.go
+++ b/ir/metadata/metadata.go
@@ -71,10 +71,9 @@ func (md *Tuple) String() string {
 
 // Ident returns the identifier associated with the metadata tuple.
 func (md *Tuple) Ident() string {
-	// TODO: tuple field ever null?
-	//if md == nil {
-	//	return "null"
-	//}
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}

--- a/ir/metadata/metadata_test.go
+++ b/ir/metadata/metadata_test.go
@@ -7,14 +7,14 @@ import (
 
 // Assert that each metadata node implements the metadata.Node interface.
 var (
-	_ Node = (*Def)(nil)
+	_ Node = (Definition)(nil)
 	_ Node = (*DIExpression)(nil)
 )
 
 // Assert that each metadata node implements the metadata.MDNode interface.
 var (
 	_ MDNode = (*Tuple)(nil)
-	_ MDNode = (*Def)(nil)
+	_ MDNode = (Definition)(nil)
 	_ MDNode = (SpecializedNode)(nil)
 )
 
@@ -74,6 +74,6 @@ var (
 	_ Metadata = (value.Value)(nil)
 	_ Metadata = (*String)(nil)
 	_ Metadata = (*Tuple)(nil)
-	_ Metadata = (*Def)(nil)
+	_ Metadata = (Definition)(nil)
 	_ Metadata = (SpecializedNode)(nil)
 )

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -727,15 +727,8 @@ type DIGlobalVariableExpression struct {
 	// (optional) Distinct.
 	Distinct bool
 
-	Var Field // required.
-
-	// Note, the C++ source code of LLVM states that "expr:" is a required field,
-	// however, Clang is known to output DIGlobalVariableExpression specialized
-	// metadata nodes only containing "var:"; e.g. from `cat.ll`:
-	//
-	//    !0 = !DIGlobalVariableExpression(var: !1)
-
-	Expr Field // required.
+	Var  Field         // required.
+	Expr *DIExpression // required.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -192,7 +192,7 @@ type DICompositeType struct {
 	Tag            enum.DwarfTag  // required.
 	Name           string         // optional; empty if not present.
 	Scope          Field          // optional; nil if not present.
-	File           Field          // optional; nil if not present.
+	File           *DIFile        // optional; nil if not present.
 	Line           int64          // optional; zero value if not present.
 	BaseType       Field          // optional; nil if not present.
 	Size           uint64         // optional; zero value if not present.
@@ -301,7 +301,7 @@ type DIDerivedType struct {
 	Tag               enum.DwarfTag // required.
 	Name              string        // optional; empty if not present.
 	Scope             Field         // optional; nil if not present.
-	File              Field         // optional; nil if not present.
+	File              *DIFile       // optional; nil if not present.
 	Line              int64         // optional; zero value if not present.
 	BaseType          Field         // required.
 	Size              uint64        // optional; zero value if not present.
@@ -526,17 +526,17 @@ type DIGlobalVariable struct {
 	// present.
 	MetadataID
 
-	Name           string // required.
-	Scope          Field  // optional; nil if not present.
-	LinkageName    string // optional; empty if not present.
-	File           Field  // optional; nil if not present.
-	Line           int64  // optional; zero value if not present.
-	Type           Field  // optional; nil if not present.
-	IsLocal        bool   // optional; zero value if not present.
-	IsDefinition   bool   // optional; zero value if not present.
-	TemplateParams Field  // optional; nil if not present.
-	Declaration    Field  // optional; nil if not present.
-	Align          uint64 // optional; zero value if not present.
+	Name           string  // required.
+	Scope          Field   // optional; nil if not present.
+	LinkageName    string  // optional; empty if not present.
+	File           *DIFile // optional; nil if not present.
+	Line           int64   // optional; zero value if not present.
+	Type           Field   // optional; nil if not present.
+	IsLocal        bool    // optional; zero value if not present.
+	IsDefinition   bool    // optional; zero value if not present.
+	TemplateParams Field   // optional; nil if not present.
+	Declaration    Field   // optional; nil if not present.
+	Align          uint64  // optional; zero value if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -662,7 +662,7 @@ type DIImportedEntity struct {
 	Tag    enum.DwarfTag // required.
 	Scope  Field         // required.
 	Entity Field         // optional; nil if not present.
-	File   Field         // optional; nil if not present.
+	File   *DIFile       // optional; nil if not present.
 	Line   int64         // optional; zero value if not present.
 	Name   string        // optional; empty if not present.
 }
@@ -716,10 +716,10 @@ type DILabel struct {
 	// present.
 	MetadataID
 
-	Scope Field  // required.
-	Name  string // required.
-	File  Field  // required.
-	Line  int64  // required.
+	Scope Field   // required.
+	Name  string  // required.
+	File  *DIFile // required.
+	Line  int64   // required.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -759,10 +759,10 @@ type DILexicalBlock struct {
 	// present.
 	MetadataID
 
-	Scope  Field // required.
-	File   Field // optional; nil if not present.
-	Line   int64 // optional; zero value if not present.
-	Column int64 // optional; zero value if not present.
+	Scope  Field   // required.
+	File   *DIFile // optional; nil if not present.
+	Line   int64   // optional; zero value if not present.
+	Column int64   // optional; zero value if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -808,9 +808,9 @@ type DILexicalBlockFile struct {
 	// present.
 	MetadataID
 
-	Scope         Field  // required.
-	File          Field  // optional; nil if not present.
-	Discriminator uint64 // required.
+	Scope         Field   // required.
+	File          *DIFile // optional; nil if not present.
+	Discriminator uint64  // required.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -854,7 +854,7 @@ type DILocalVariable struct {
 	Name  string      // optional; empty if not present.
 	Arg   uint64      // optional; zero value if not present.
 	Scope Field       // required.
-	File  Field       // optional; nil if not present.
+	File  *DIFile     // optional; nil if not present.
 	Line  int64       // optional; zero value if not present.
 	Type  Field       // optional; nil if not present.
 	Flags enum.DIFlag // optional.
@@ -1023,7 +1023,7 @@ type DIMacroFile struct {
 
 	Type  enum.DwarfMacinfo // optional; zero value if not present.
 	Line  int64             // optional; zero value if not present.
-	File  Field             // required.
+	File  *DIFile           // required.
 	Nodes Field             // optional; nil if not present.
 }
 
@@ -1166,13 +1166,13 @@ type DIObjCProperty struct {
 	// present.
 	MetadataID
 
-	Name       string // optional; empty if not present.
-	File       Field  // optional; nil if not present.
-	Line       int64  // optional; zero value if not present.
-	Setter     string // optional; empty if not present.
-	Getter     string // optional; empty if not present.
-	Attributes uint64 // optional; zero value if not present.
-	Type       Field  // optional; nil if not present.
+	Name       string  // optional; empty if not present.
+	File       *DIFile // optional; nil if not present.
+	Line       int64   // optional; zero value if not present.
+	Setter     string  // optional; empty if not present.
+	Getter     string  // optional; empty if not present.
+	Attributes uint64  // optional; zero value if not present.
+	Type       Field   // optional; nil if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -1235,7 +1235,7 @@ type DISubprogram struct {
 	Scope          Field                // optional; nil if not present.
 	Name           string               // optional; empty if not present.
 	LinkageName    string               // optional; empty if not present.
-	File           Field                // optional; nil if not present.
+	File           *DIFile              // optional; nil if not present.
 	Line           int64                // optional; zero value if not present.
 	Type           Field                // optional; nil if not present.
 	IsLocal        bool                 // optional; zero value if not present.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -14,6 +14,8 @@ type DIBasicType struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag      enum.DwarfTag         // optional; zero value if not present.
 	Name     string                // optional; empty if not present.
@@ -41,6 +43,10 @@ func (md *DIBasicType) Ident() string {
 // node.
 func (md *DIBasicType) LLString() string {
 	// '!DIBasicType' '(' Fields=(DIBasicTypeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if md.Tag != 0 {
 		field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
@@ -66,7 +72,13 @@ func (md *DIBasicType) LLString() string {
 		field := fmt.Sprintf("flags: %s", diFlagsString(md.Flags))
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIBasicType(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIBasicType(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIBasicType) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DICompileUnit ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -76,6 +88,8 @@ type DICompileUnit struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Language              enum.DwarfLang     // required.
 	File                  *DIFile            // required.
@@ -89,7 +103,7 @@ type DICompileUnit struct {
 	RetainedTypes         Field              // optional; nil if not present.
 	Globals               Field              // optional; nil if not present.
 	Imports               Field              // optional; nil if not present.
-	Macros                Field              // optional; nil if not present.
+	Macros                *Tuple             // optional; nil if not present.
 	DwoID                 uint64             // optional; zero value if not present.
 	SplitDebugInlining    bool               // optional; zero value if not present.
 	DebugInfoForProfiling bool               // optional; zero value if not present.
@@ -113,6 +127,10 @@ func (md *DICompileUnit) Ident() string {
 // node.
 func (md *DICompileUnit) LLString() string {
 	// '!DICompileUnit' '(' Fields=(DICompileUnitField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("language: %s", md.Language)
 	fields = append(fields, field)
@@ -178,7 +196,13 @@ func (md *DICompileUnit) LLString() string {
 		field = fmt.Sprintf("nameTableKind: %s", md.NameTableKind)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DICompileUnit(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DICompileUnit(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DICompileUnit) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DICompositeType ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,6 +212,8 @@ type DICompositeType struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag            enum.DwarfTag  // required.
 	Name           string         // optional; empty if not present.
@@ -224,6 +250,10 @@ func (md *DICompositeType) Ident() string {
 // node.
 func (md *DICompositeType) LLString() string {
 	// '!DICompositeType' '(' Fields=(DICompositeTypeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
 	fields = append(fields, field)
@@ -287,7 +317,13 @@ func (md *DICompositeType) LLString() string {
 		field := fmt.Sprintf("discriminator: %s", md.Discriminator)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DICompositeType(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DICompositeType(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DICompositeType) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIDerivedType ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -297,6 +333,8 @@ type DIDerivedType struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag               enum.DwarfTag // required.
 	Name              string        // optional; empty if not present.
@@ -329,6 +367,10 @@ func (md *DIDerivedType) Ident() string {
 // node.
 func (md *DIDerivedType) LLString() string {
 	// '!DIDerivedType' '(' Fields=(DIDerivedTypeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
 	fields = append(fields, field)
@@ -374,7 +416,13 @@ func (md *DIDerivedType) LLString() string {
 		field := fmt.Sprintf("dwarfAddressSpace: %d", md.DwarfAddressSpace)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIDerivedType(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIDerivedType(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIDerivedType) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIEnumerator ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -384,6 +432,8 @@ type DIEnumerator struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Name       string // required.
 	Value      int64  // required.
@@ -407,6 +457,10 @@ func (md *DIEnumerator) Ident() string {
 // node.
 func (md *DIEnumerator) LLString() string {
 	// '!DIEnumerator' '(' Fields=(DIEnumeratorField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("name: %s", quote(md.Name))
 	fields = append(fields, field)
@@ -420,7 +474,13 @@ func (md *DIEnumerator) LLString() string {
 		field := fmt.Sprintf("isUnsigned: %t", md.IsUnsigned)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIEnumerator(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIEnumerator(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIEnumerator) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIExpression ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -430,6 +490,8 @@ type DIExpression struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Fields []DIExpressionField
 }
@@ -452,6 +514,9 @@ func (md *DIExpression) Ident() string {
 func (md *DIExpression) LLString() string {
 	// '!DIExpression' '(' Fields=(DIExpressionField separator ',')* ')'
 	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	buf.WriteString("!DIExpression(")
 	for i, field := range md.Fields {
 		if i != 0 {
@@ -463,6 +528,11 @@ func (md *DIExpression) LLString() string {
 	return buf.String()
 }
 
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIExpression) SetDistinct(distinct bool) {
+	md.Distinct = distinct
+}
+
 // ~~~ [ DIFile ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // DIFile is a specialized metadata node.
@@ -470,6 +540,8 @@ type DIFile struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Filename     string            // required.
 	Directory    string            // required.
@@ -498,6 +570,10 @@ func (md *DIFile) Ident() string {
 // node.
 func (md *DIFile) LLString() string {
 	// '!DIFile' '(' Fields=(DIFileField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("filename: %s", quote(md.Filename))
 	fields = append(fields, field)
@@ -515,7 +591,13 @@ func (md *DIFile) LLString() string {
 		field := fmt.Sprintf("source: %s", quote(md.Source))
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIFile(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIFile(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIFile) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIGlobalVariable ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -525,6 +607,8 @@ type DIGlobalVariable struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Name           string  // required.
 	Scope          Field   // optional; nil if not present.
@@ -556,6 +640,10 @@ func (md *DIGlobalVariable) Ident() string {
 // node.
 func (md *DIGlobalVariable) LLString() string {
 	// '!DIGlobalVariable' '(' Fields=(DIGlobalVariableField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("name: %s", quote(md.Name))
 	fields = append(fields, field)
@@ -599,7 +687,13 @@ func (md *DIGlobalVariable) LLString() string {
 		field := fmt.Sprintf("align: %d", md.Align)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIGlobalVariable(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIGlobalVariable(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIGlobalVariable) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIGlobalVariableExpression ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -609,6 +703,8 @@ type DIGlobalVariableExpression struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Var Field // required.
 
@@ -639,6 +735,10 @@ func (md *DIGlobalVariableExpression) Ident() string {
 func (md *DIGlobalVariableExpression) LLString() string {
 	// '!DIGlobalVariableExpression' '(' Fields=(DIGlobalVariableExpressionField
 	// separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("var: %s", md.Var)
 	fields = append(fields, field)
@@ -648,7 +748,13 @@ func (md *DIGlobalVariableExpression) LLString() string {
 		field = fmt.Sprintf("expr: %s", md.Expr)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIGlobalVariableExpression(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIGlobalVariableExpression(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIGlobalVariableExpression) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIImportedEntity ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -658,6 +764,8 @@ type DIImportedEntity struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag    enum.DwarfTag // required.
 	Scope  Field         // required.
@@ -684,6 +792,10 @@ func (md *DIImportedEntity) Ident() string {
 // node.
 func (md *DIImportedEntity) LLString() string {
 	// '!DIImportedEntity' '(' Fields=(DIImportedEntityField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
 	fields = append(fields, field)
@@ -705,7 +817,13 @@ func (md *DIImportedEntity) LLString() string {
 		field := fmt.Sprintf("name: %s", quote(md.Name))
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIImportedEntity(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIImportedEntity(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIImportedEntity) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DILabel ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -715,6 +833,8 @@ type DILabel struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope Field   // required.
 	Name  string  // required.
@@ -739,6 +859,10 @@ func (md *DILabel) Ident() string {
 // node.
 func (md *DILabel) LLString() string {
 	// '!DILabel' '(' Fields=(DILabelField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -748,7 +872,13 @@ func (md *DILabel) LLString() string {
 	fields = append(fields, field)
 	field = fmt.Sprintf("line: %d", md.Line)
 	fields = append(fields, field)
-	return fmt.Sprintf("!DILabel(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DILabel(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DILabel) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DILexicalBlock ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -758,6 +888,8 @@ type DILexicalBlock struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope  Field   // required.
 	File   *DIFile // optional; nil if not present.
@@ -782,6 +914,10 @@ func (md *DILexicalBlock) Ident() string {
 // node.
 func (md *DILexicalBlock) LLString() string {
 	// '!DILexicalBlock' '(' Fields=(DILexicalBlockField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -797,7 +933,13 @@ func (md *DILexicalBlock) LLString() string {
 		field := fmt.Sprintf("column: %d", md.Column)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DILexicalBlock(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DILexicalBlock(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DILexicalBlock) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DILexicalBlockFile ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -807,6 +949,8 @@ type DILexicalBlockFile struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope         Field   // required.
 	File          *DIFile // optional; nil if not present.
@@ -831,6 +975,10 @@ func (md *DILexicalBlockFile) Ident() string {
 func (md *DILexicalBlockFile) LLString() string {
 	// '!DILexicalBlockFile' '(' Fields=(DILexicalBlockFileField separator ',')*
 	// ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -840,7 +988,13 @@ func (md *DILexicalBlockFile) LLString() string {
 	}
 	field = fmt.Sprintf("discriminator: %d", md.Discriminator)
 	fields = append(fields, field)
-	return fmt.Sprintf("!DILexicalBlockFile(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DILexicalBlockFile(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DILexicalBlockFile) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DILocalVariable ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -850,6 +1004,8 @@ type DILocalVariable struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Name  string      // optional; empty if not present.
 	Arg   uint64      // optional; zero value if not present.
@@ -878,6 +1034,10 @@ func (md *DILocalVariable) Ident() string {
 // node.
 func (md *DILocalVariable) LLString() string {
 	// '!DILocalVariable' '(' Fields=(DILocalVariableField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if len(md.Name) > 0 {
 		field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -909,7 +1069,13 @@ func (md *DILocalVariable) LLString() string {
 		field := fmt.Sprintf("align: %d", md.Align)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DILocalVariable(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DILocalVariable(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DILocalVariable) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DILocation ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -919,6 +1085,8 @@ type DILocation struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Line           int64 // optional; zero value if not present.
 	Column         int64 // optional; zero value if not present.
@@ -944,6 +1112,10 @@ func (md *DILocation) Ident() string {
 // node.
 func (md *DILocation) LLString() string {
 	// '!DILocation' '(' Fields=(DILocationField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if md.Line != 0 {
 		field := fmt.Sprintf("line: %d", md.Line)
@@ -963,7 +1135,13 @@ func (md *DILocation) LLString() string {
 		field := fmt.Sprintf("isImplicitCode: %t", md.IsImplicitCode)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DILocation(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DILocation(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DILocation) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIMacro ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -973,6 +1151,8 @@ type DIMacro struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Type  enum.DwarfMacinfo // required.
 	Line  int64             // optional; zero value if not present.
@@ -997,6 +1177,10 @@ func (md *DIMacro) Ident() string {
 // node.
 func (md *DIMacro) LLString() string {
 	// '!DIMacro' '(' Fields=(DIMacroField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("type: %s", md.Type)
 	fields = append(fields, field)
@@ -1010,7 +1194,13 @@ func (md *DIMacro) LLString() string {
 		field := fmt.Sprintf("value: %s", quote(md.Value))
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIMacro(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIMacro(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIMacro) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIMacroFile ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1020,6 +1210,8 @@ type DIMacroFile struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Type  enum.DwarfMacinfo // optional; zero value if not present.
 	Line  int64             // optional; zero value if not present.
@@ -1044,6 +1236,10 @@ func (md *DIMacroFile) Ident() string {
 // node.
 func (md *DIMacroFile) LLString() string {
 	// '!DIMacroFile' '(' Fields=(DIMacroFileField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if md.Type != 0 {
 		field := fmt.Sprintf("type: %s", md.Type)
@@ -1059,7 +1255,13 @@ func (md *DIMacroFile) LLString() string {
 		field := fmt.Sprintf("nodes: %s", md.Nodes)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIMacroFile(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIMacroFile(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIMacroFile) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIModule ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1069,6 +1271,8 @@ type DIModule struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope        Field  // required.
 	Name         string // required.
@@ -1094,6 +1298,10 @@ func (md *DIModule) Ident() string {
 // node.
 func (md *DIModule) LLString() string {
 	// '!DIModule' '(' Fields=(DIModuleField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -1111,7 +1319,13 @@ func (md *DIModule) LLString() string {
 		field := fmt.Sprintf("isysroot: %s", quote(md.Isysroot))
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIModule(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIModule(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIModule) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DINamespace ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1121,6 +1335,8 @@ type DINamespace struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope         Field  // required.
 	Name          string // optional; empty if not present.
@@ -1144,6 +1360,10 @@ func (md *DINamespace) Ident() string {
 // node.
 func (md *DINamespace) LLString() string {
 	// '!DINamespace' '(' Fields=(DINamespaceField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -1155,7 +1375,13 @@ func (md *DINamespace) LLString() string {
 		field := fmt.Sprintf("exportSymbols: %t", md.ExportSymbols)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DINamespace(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DINamespace(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DINamespace) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DIObjCProperty ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1165,6 +1391,8 @@ type DIObjCProperty struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Name       string  // optional; empty if not present.
 	File       *DIFile // optional; nil if not present.
@@ -1192,6 +1420,10 @@ func (md *DIObjCProperty) Ident() string {
 // node.
 func (md *DIObjCProperty) LLString() string {
 	// '!DIObjCProperty' '(' Fields=(DIObjCPropertyField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if len(md.Name) > 0 {
 		field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -1221,7 +1453,13 @@ func (md *DIObjCProperty) LLString() string {
 		field := fmt.Sprintf("type: %s", md.Type)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DIObjCProperty(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DIObjCProperty(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DIObjCProperty) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DISubprogram ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1231,6 +1469,8 @@ type DISubprogram struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Scope          Field                // optional; nil if not present.
 	Name           string               // optional; empty if not present.
@@ -1271,6 +1511,10 @@ func (md *DISubprogram) Ident() string {
 // node.
 func (md *DISubprogram) LLString() string {
 	// '!DISubprogram' '(' Fields=(DISubprogramField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	// Note, to match Clang output, the output order is changed to output name
 	// before scope.
@@ -1356,7 +1600,13 @@ func (md *DISubprogram) LLString() string {
 		field := fmt.Sprintf("thrownTypes: %s", md.ThrownTypes)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DISubprogram(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DISubprogram(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DISubprogram) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DISubrange ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1366,6 +1616,8 @@ type DISubrange struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Count      FieldOrInt // required.
 	LowerBound int64      // optional; zero value if not present.
@@ -1388,6 +1640,10 @@ func (md *DISubrange) Ident() string {
 // node.
 func (md *DISubrange) LLString() string {
 	// '!DISubrange' '(' Fields=(DISubrangeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("count: %s", md.Count)
 	fields = append(fields, field)
@@ -1395,7 +1651,13 @@ func (md *DISubrange) LLString() string {
 		field := fmt.Sprintf("lowerBound: %d", md.LowerBound)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!DISubrange(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DISubrange(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DISubrange) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DISubroutineType ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1405,6 +1667,8 @@ type DISubroutineType struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Flags enum.DIFlag  // optional.
 	CC    enum.DwarfCC // optional; zero value if not present.
@@ -1428,6 +1692,10 @@ func (md *DISubroutineType) Ident() string {
 // node.
 func (md *DISubroutineType) LLString() string {
 	// '!DISubroutineType' '(' Fields=(DISubroutineTypeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if md.Flags != 0 {
 		field := fmt.Sprintf("flags: %s", diFlagsString(md.Flags))
@@ -1439,7 +1707,13 @@ func (md *DISubroutineType) LLString() string {
 	}
 	field := fmt.Sprintf("types: %s", md.Types)
 	fields = append(fields, field)
-	return fmt.Sprintf("!DISubroutineType(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DISubroutineType(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DISubroutineType) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DITemplateTypeParameter ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1449,6 +1723,8 @@ type DITemplateTypeParameter struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Name string // optional; empty if not present.
 	Type Field  // required.
@@ -1472,6 +1748,10 @@ func (md *DITemplateTypeParameter) Ident() string {
 func (md *DITemplateTypeParameter) LLString() string {
 	// '!DITemplateTypeParameter' '(' Fields=(DITemplateTypeParameterField
 	// separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if len(md.Name) > 0 {
 		field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -1479,7 +1759,13 @@ func (md *DITemplateTypeParameter) LLString() string {
 	}
 	field := fmt.Sprintf("type: %s", md.Type)
 	fields = append(fields, field)
-	return fmt.Sprintf("!DITemplateTypeParameter(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DITemplateTypeParameter(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DITemplateTypeParameter) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ DITemplateValueParameter ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1489,6 +1775,8 @@ type DITemplateValueParameter struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag   enum.DwarfTag // optional; zero value if not present.
 	Name  string        // optional; empty if not present.
@@ -1513,6 +1801,10 @@ func (md *DITemplateValueParameter) Ident() string {
 // node.
 func (md *DITemplateValueParameter) LLString() string {
 	// '!DITemplateValueParameter' '(' Fields=(DITemplateValueParameterField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	if md.Tag != 0 {
 		field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
@@ -1528,7 +1820,13 @@ func (md *DITemplateValueParameter) LLString() string {
 	}
 	field := fmt.Sprintf("value: %s", md.Value)
 	fields = append(fields, field)
-	return fmt.Sprintf("!DITemplateValueParameter(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!DITemplateValueParameter(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *DITemplateValueParameter) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }
 
 // ~~~ [ GenericDINode ] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1538,6 +1836,8 @@ type GenericDINode struct {
 	// Metadata ID associated with the specialized metadata node; -1 if not
 	// present.
 	MetadataID
+	// (optional) Distinct.
+	Distinct bool
 
 	Tag      enum.DwarfTag // required
 	Header   string        // optional; empty if not present
@@ -1561,6 +1861,10 @@ func (md *GenericDINode) Ident() string {
 // node.
 func (md *GenericDINode) LLString() string {
 	// '!GenericDINode' '(' Fields=(GenericDINodeField separator ',')* ')'
+	buf := &strings.Builder{}
+	if md.Distinct {
+		buf.WriteString("distinct ")
+	}
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
 	fields = append(fields, field)
@@ -1582,5 +1886,11 @@ func (md *GenericDINode) LLString() string {
 		field = fmt.Sprintf("operands: %s", buf)
 		fields = append(fields, field)
 	}
-	return fmt.Sprintf("!GenericDINode(%s)", strings.Join(fields, ", "))
+	fmt.Fprintf(buf, "!GenericDINode(%s)", strings.Join(fields, ", "))
+	return buf.String()
+}
+
+// SetDistinct specifies whether the metadata definition is dinstict.
+func (md *GenericDINode) SetDistinct(distinct bool) {
+	md.Distinct = distinct
 }

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -1120,11 +1120,11 @@ type DILocation struct {
 	// (optional) Distinct.
 	Distinct bool
 
-	Line           int64 // optional; zero value if not present.
-	Column         int64 // optional; zero value if not present.
-	Scope          Field // required.
-	InlinedAt      Field // optional; nil if not present.
-	IsImplicitCode bool  // optional; zero value if not present.
+	Line           int64       // optional; zero value if not present.
+	Column         int64       // optional; zero value if not present.
+	Scope          Field       // required.
+	InlinedAt      *DILocation // optional; nil if not present.
+	IsImplicitCode bool        // optional; zero value if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -11,6 +11,10 @@ import (
 
 // DIBasicType is a specialized metadata node.
 type DIBasicType struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag      enum.DwarfTag         // optional; zero value if not present.
 	Name     string                // optional; empty if not present.
 	Size     uint64                // optional; zero value if not present.
@@ -19,8 +23,23 @@ type DIBasicType struct {
 	Flags    enum.DIFlag           // optional.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata
+// node.
 func (md *DIBasicType) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIBasicType) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIBasicType) LLString() string {
 	// '!DIBasicType' '(' Fields=(DIBasicTypeField separator ',')* ')'
 	var fields []string
 	if md.Tag != 0 {
@@ -54,6 +73,10 @@ func (md *DIBasicType) String() string {
 
 // DICompileUnit is a specialized metadata node.
 type DICompileUnit struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Language              enum.DwarfLang     // required.
 	File                  Field              // required.
 	Producer              string             // optional; empty if not present.
@@ -73,8 +96,22 @@ type DICompileUnit struct {
 	NameTableKind         enum.NameTableKind // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DICompileUnit) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DICompileUnit) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DICompileUnit) LLString() string {
 	// '!DICompileUnit' '(' Fields=(DICompileUnitField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("language: %s", md.Language)
@@ -148,6 +185,10 @@ func (md *DICompileUnit) String() string {
 
 // DICompositeType is a specialized metadata node.
 type DICompositeType struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag            enum.DwarfTag  // required.
 	Name           string         // optional; empty if not present.
 	Scope          Field          // optional; nil if not present.
@@ -166,8 +207,22 @@ type DICompositeType struct {
 	Discriminator  Field          // optional; nil if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DICompositeType) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DICompositeType) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DICompositeType) LLString() string {
 	// '!DICompositeType' '(' Fields=(DICompositeTypeField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
@@ -239,6 +294,10 @@ func (md *DICompositeType) String() string {
 
 // DIDerivedType is a specialized metadata node.
 type DIDerivedType struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag               enum.DwarfTag // required.
 	Name              string        // optional; empty if not present.
 	Scope             Field         // optional; nil if not present.
@@ -253,8 +312,22 @@ type DIDerivedType struct {
 	DwarfAddressSpace uint64        // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIDerivedType) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIDerivedType) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIDerivedType) LLString() string {
 	// '!DIDerivedType' '(' Fields=(DIDerivedTypeField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
@@ -308,13 +381,31 @@ func (md *DIDerivedType) String() string {
 
 // DIEnumerator is a specialized metadata node.
 type DIEnumerator struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Name       string // required.
 	Value      int64  // required.
 	IsUnsigned bool   // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIEnumerator) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIEnumerator) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIEnumerator) LLString() string {
 	// '!DIEnumerator' '(' Fields=(DIEnumeratorField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -336,11 +427,29 @@ func (md *DIEnumerator) String() string {
 
 // DIExpression is a specialized metadata node.
 type DIExpression struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Fields []DIExpressionField
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIExpression) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIExpression) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIExpression) LLString() string {
 	// '!DIExpression' '(' Fields=(DIExpressionField separator ',')* ')'
 	buf := &strings.Builder{}
 	buf.WriteString("!DIExpression(")
@@ -358,6 +467,10 @@ func (md *DIExpression) String() string {
 
 // DIFile is a specialized metadata node.
 type DIFile struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Filename     string            // required.
 	Directory    string            // required.
 	Checksumkind enum.ChecksumKind // optional; zero value if not present.
@@ -365,8 +478,22 @@ type DIFile struct {
 	Source       string            // optional; empty if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIFile) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIFile) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIFile) LLString() string {
 	// '!DIFile' '(' Fields=(DIFileField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("filename: %s", quote(md.Filename))
@@ -392,6 +519,10 @@ func (md *DIFile) String() string {
 
 // DIGlobalVariable is a specialized metadata node.
 type DIGlobalVariable struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Name           string // required.
 	Scope          Field  // optional; nil if not present.
 	LinkageName    string // optional; empty if not present.
@@ -405,8 +536,22 @@ type DIGlobalVariable struct {
 	Align          uint64 // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIGlobalVariable) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIGlobalVariable) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIGlobalVariable) LLString() string {
 	// '!DIGlobalVariable' '(' Fields=(DIGlobalVariableField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -458,6 +603,10 @@ func (md *DIGlobalVariable) String() string {
 
 // DIGlobalVariableExpression is a specialized metadata node.
 type DIGlobalVariableExpression struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Var Field // required.
 
 	// Note, the C++ source code of LLVM states that "expr:" is a required field,
@@ -469,9 +618,24 @@ type DIGlobalVariableExpression struct {
 	Expr Field // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIGlobalVariableExpression) String() string {
-	// '!DIGlobalVariableExpression' '(' Fields=(DIGlobalVariableExpressionField separator ',')* ')'
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIGlobalVariableExpression) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIGlobalVariableExpression) LLString() string {
+	// '!DIGlobalVariableExpression' '(' Fields=(DIGlobalVariableExpressionField
+	// separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("var: %s", md.Var)
 	fields = append(fields, field)
@@ -488,6 +652,10 @@ func (md *DIGlobalVariableExpression) String() string {
 
 // DIImportedEntity is a specialized metadata node.
 type DIImportedEntity struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag    enum.DwarfTag // required.
 	Scope  Field         // required.
 	Entity Field         // optional; nil if not present.
@@ -496,8 +664,22 @@ type DIImportedEntity struct {
 	Name   string        // optional; empty if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIImportedEntity) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIImportedEntity) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIImportedEntity) LLString() string {
 	// '!DIImportedEntity' '(' Fields=(DIImportedEntityField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))
@@ -527,14 +709,32 @@ func (md *DIImportedEntity) String() string {
 
 // DILabel is a specialized metadata node.
 type DILabel struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope Field  // required.
 	Name  string // required.
 	File  Field  // required.
 	Line  int64  // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DILabel) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DILabel) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DILabel) LLString() string {
 	// '!DILabel' '(' Fields=(DILabelField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
@@ -552,14 +752,32 @@ func (md *DILabel) String() string {
 
 // DILexicalBlock is a specialized metadata node.
 type DILexicalBlock struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope  Field // required.
 	File   Field // optional; nil if not present.
 	Line   int64 // optional; zero value if not present.
 	Column int64 // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DILexicalBlock) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DILexicalBlock) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DILexicalBlock) LLString() string {
 	// '!DILexicalBlock' '(' Fields=(DILexicalBlockField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
@@ -583,14 +801,33 @@ func (md *DILexicalBlock) String() string {
 
 // DILexicalBlockFile is a specialized metadata node.
 type DILexicalBlockFile struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope         Field  // required.
 	File          Field  // optional; nil if not present.
 	Discriminator uint64 // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DILexicalBlockFile) String() string {
-	// '!DILexicalBlockFile' '(' Fields=(DILexicalBlockFileField separator ',')* ')'
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DILexicalBlockFile) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DILexicalBlockFile) LLString() string {
+	// '!DILexicalBlockFile' '(' Fields=(DILexicalBlockFileField separator ',')*
+	// ')'
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
 	fields = append(fields, field)
@@ -607,6 +844,10 @@ func (md *DILexicalBlockFile) String() string {
 
 // DILocalVariable is a specialized metadata node.
 type DILocalVariable struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Name  string      // optional; empty if not present.
 	Arg   uint64      // optional; zero value if not present.
 	Scope Field       // required.
@@ -617,8 +858,22 @@ type DILocalVariable struct {
 	Align uint64      // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DILocalVariable) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DILocalVariable) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DILocalVariable) LLString() string {
 	// '!DILocalVariable' '(' Fields=(DILocalVariableField separator ',')* ')'
 	var fields []string
 	if len(md.Name) > 0 {
@@ -658,6 +913,10 @@ func (md *DILocalVariable) String() string {
 
 // DILocation is a specialized metadata node.
 type DILocation struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Line           int64 // optional; zero value if not present.
 	Column         int64 // optional; zero value if not present.
 	Scope          Field // required.
@@ -665,8 +924,22 @@ type DILocation struct {
 	IsImplicitCode bool  // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DILocation) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DILocation) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DILocation) LLString() string {
 	// '!DILocation' '(' Fields=(DILocationField separator ',')* ')'
 	var fields []string
 	if md.Line != 0 {
@@ -694,14 +967,32 @@ func (md *DILocation) String() string {
 
 // DIMacro is a specialized metadata node.
 type DIMacro struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Type  enum.DwarfMacinfo // required.
 	Line  int64             // optional; zero value if not present.
 	Name  string            // required.
 	Value string            // optional; empty if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIMacro) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIMacro) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIMacro) LLString() string {
 	// '!DIMacro' '(' Fields=(DIMacroField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("type: %s", md.Type)
@@ -723,14 +1014,32 @@ func (md *DIMacro) String() string {
 
 // DIMacroFile is a specialized metadata node.
 type DIMacroFile struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Type  enum.DwarfMacinfo // optional; zero value if not present.
 	Line  int64             // optional; zero value if not present.
 	File  Field             // required.
 	Nodes Field             // optional; nil if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIMacroFile) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIMacroFile) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIMacroFile) LLString() string {
 	// '!DIMacroFile' '(' Fields=(DIMacroFileField separator ',')* ')'
 	var fields []string
 	if md.Type != 0 {
@@ -754,6 +1063,10 @@ func (md *DIMacroFile) String() string {
 
 // DIModule is a specialized metadata node.
 type DIModule struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope        Field  // required.
 	Name         string // required.
 	ConfigMacros string // optional; empty if not present.
@@ -761,8 +1074,22 @@ type DIModule struct {
 	Isysroot     string // optional; empty if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIModule) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIModule) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIModule) LLString() string {
 	// '!DIModule' '(' Fields=(DIModuleField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
@@ -788,13 +1115,31 @@ func (md *DIModule) String() string {
 
 // DINamespace is a specialized metadata node.
 type DINamespace struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope         Field  // required.
 	Name          string // optional; empty if not present.
 	ExportSymbols bool   // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DINamespace) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DINamespace) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DINamespace) LLString() string {
 	// '!DINamespace' '(' Fields=(DINamespaceField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("scope: %s", md.Scope)
@@ -814,6 +1159,10 @@ func (md *DINamespace) String() string {
 
 // DIObjCProperty is a specialized metadata node.
 type DIObjCProperty struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Name       string // optional; empty if not present.
 	File       Field  // optional; nil if not present.
 	Line       int64  // optional; zero value if not present.
@@ -823,8 +1172,22 @@ type DIObjCProperty struct {
 	Type       Field  // optional; nil if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DIObjCProperty) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DIObjCProperty) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DIObjCProperty) LLString() string {
 	// '!DIObjCProperty' '(' Fields=(DIObjCPropertyField separator ',')* ')'
 	var fields []string
 	if len(md.Name) > 0 {
@@ -862,6 +1225,10 @@ func (md *DIObjCProperty) String() string {
 
 // DISubprogram is a specialized metadata node.
 type DISubprogram struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Scope          Field                // optional; nil if not present.
 	Name           string               // optional; empty if not present.
 	LinkageName    string               // optional; empty if not present.
@@ -884,8 +1251,22 @@ type DISubprogram struct {
 	ThrownTypes    Field                // optional; nil if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DISubprogram) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DISubprogram) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DISubprogram) LLString() string {
 	// '!DISubprogram' '(' Fields=(DISubprogramField separator ',')* ')'
 	var fields []string
 	// Note, to match Clang output, the output order is changed to output name
@@ -979,12 +1360,30 @@ func (md *DISubprogram) String() string {
 
 // DISubrange is a specialized metadata node.
 type DISubrange struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Count      FieldOrInt // required.
 	LowerBound int64      // optional; zero value if not present.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DISubrange) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DISubrange) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DISubrange) LLString() string {
 	// '!DISubrange' '(' Fields=(DISubrangeField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("count: %s", md.Count)
@@ -1000,13 +1399,31 @@ func (md *DISubrange) String() string {
 
 // DISubroutineType is a specialized metadata node.
 type DISubroutineType struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Flags enum.DIFlag  // optional.
 	CC    enum.DwarfCC // optional; zero value if not present.
 	Types Field        // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DISubroutineType) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DISubroutineType) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DISubroutineType) LLString() string {
 	// '!DISubroutineType' '(' Fields=(DISubroutineTypeField separator ',')* ')'
 	var fields []string
 	if md.Flags != 0 {
@@ -1026,13 +1443,32 @@ func (md *DISubroutineType) String() string {
 
 // DITemplateTypeParameter is a specialized metadata node.
 type DITemplateTypeParameter struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Name string // optional; empty if not present.
 	Type Field  // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DITemplateTypeParameter) String() string {
-	// '!DITemplateTypeParameter' '(' Fields=(DITemplateTypeParameterField separator ',')* ')'
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DITemplateTypeParameter) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DITemplateTypeParameter) LLString() string {
+	// '!DITemplateTypeParameter' '(' Fields=(DITemplateTypeParameterField
+	// separator ',')* ')'
 	var fields []string
 	if len(md.Name) > 0 {
 		field := fmt.Sprintf("name: %s", quote(md.Name))
@@ -1047,14 +1483,32 @@ func (md *DITemplateTypeParameter) String() string {
 
 // DITemplateValueParameter is a specialized metadata node.
 type DITemplateValueParameter struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag   enum.DwarfTag // optional; zero value if not present.
 	Name  string        // optional; empty if not present.
 	Type  Field         // optional; nil if not present.
 	Value Field         // required.
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *DITemplateValueParameter) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *DITemplateValueParameter) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *DITemplateValueParameter) LLString() string {
 	// '!DITemplateValueParameter' '(' Fields=(DITemplateValueParameterField separator ',')* ')'
 	var fields []string
 	if md.Tag != 0 {
@@ -1078,13 +1532,31 @@ func (md *DITemplateValueParameter) String() string {
 
 // GenericDINode is a specialized GenericDINode metadata node.
 type GenericDINode struct {
+	// Metadata ID associated with the specialized metadata node; -1 if not
+	// present.
+	MetadataID
+
 	Tag      enum.DwarfTag // required
 	Header   string        // optional; empty if not present
 	Operands []Field       // optional
 }
 
-// String returns a string representation of the specialized metadata node.
+// String returns the LLVM syntax representation of the specialized metadata node.
 func (md *GenericDINode) String() string {
+	return md.Ident()
+}
+
+// Ident returns the identifier associated with the specialized metadata node.
+func (md *GenericDINode) Ident() string {
+	if md.MetadataID != -1 {
+		return md.MetadataID.Ident()
+	}
+	return md.LLString()
+}
+
+// LLString returns the LLVM syntax representation of the specialized metadata
+// node.
+func (md *GenericDINode) LLString() string {
 	// '!GenericDINode' '(' Fields=(GenericDINodeField separator ',')* ')'
 	var fields []string
 	field := fmt.Sprintf("tag: %s", dwarfTagString(md.Tag))

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -99,10 +99,10 @@ type DICompileUnit struct {
 	RuntimeVersion        uint64             // optional; zero value if not present.
 	SplitDebugFilename    string             // optional; empty if not present.
 	EmissionKind          enum.EmissionKind  // optional; zero value if not present.
-	Enums                 Field              // optional; nil if not present.
-	RetainedTypes         Field              // optional; nil if not present.
-	Globals               Field              // optional; nil if not present.
-	Imports               Field              // optional; nil if not present.
+	Enums                 *Tuple             // optional; nil if not present.
+	RetainedTypes         *Tuple             // optional; nil if not present.
+	Globals               *Tuple             // optional; nil if not present.
+	Imports               *Tuple             // optional; nil if not present.
 	Macros                *Tuple             // optional; nil if not present.
 	DwoID                 uint64             // optional; zero value if not present.
 	SplitDebugInlining    bool               // optional; zero value if not present.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -1490,8 +1490,8 @@ type DISubprogram struct {
 	Unit           Field                // optional; nil if not present.
 	TemplateParams *Tuple               // optional; nil if not present.
 	Declaration    Field                // optional; nil if not present.
-	RetainedNodes  Field                // optional; nil if not present.
-	ThrownTypes    Field                // optional; nil if not present.
+	RetainedNodes  *Tuple               // optional; nil if not present.
+	ThrownTypes    *Tuple               // optional; nil if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -1672,7 +1672,7 @@ type DISubroutineType struct {
 
 	Flags enum.DIFlag  // optional.
 	CC    enum.DwarfCC // optional; zero value if not present.
-	Types Field        // required.
+	Types *Tuple       // required.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -33,6 +33,9 @@ func (md *DIBasicType) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIBasicType) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -117,6 +120,9 @@ func (md *DICompileUnit) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DICompileUnit) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -215,22 +221,22 @@ type DICompositeType struct {
 	// (optional) Distinct.
 	Distinct bool
 
-	Tag            enum.DwarfTag  // required.
-	Name           string         // optional; empty if not present.
-	Scope          Field          // optional; nil if not present.
-	File           *DIFile        // optional; nil if not present.
-	Line           int64          // optional; zero value if not present.
-	BaseType       Field          // optional; nil if not present.
-	Size           uint64         // optional; zero value if not present.
-	Align          uint64         // optional; zero value if not present.
-	Offset         uint64         // optional; zero value if not present.
-	Flags          enum.DIFlag    // optional.
-	Elements       *Tuple         // optional; nil if not present.
-	RuntimeLang    enum.DwarfLang // optional; zero value if not present.
-	VtableHolder   Field          // optional; nil if not present.
-	TemplateParams *Tuple         // optional; nil if not present.
-	Identifier     string         // optional; empty if not present.
-	Discriminator  Field          // optional; nil if not present.
+	Tag            enum.DwarfTag    // required.
+	Name           string           // optional; empty if not present.
+	Scope          Field            // optional; nil if not present.
+	File           *DIFile          // optional; nil if not present.
+	Line           int64            // optional; zero value if not present.
+	BaseType       Field            // optional; nil if not present.
+	Size           uint64           // optional; zero value if not present.
+	Align          uint64           // optional; zero value if not present.
+	Offset         uint64           // optional; zero value if not present.
+	Flags          enum.DIFlag      // optional.
+	Elements       *Tuple           // optional; nil if not present.
+	RuntimeLang    enum.DwarfLang   // optional; zero value if not present.
+	VtableHolder   *DICompositeType // optional; nil if not present.
+	TemplateParams *Tuple           // optional; nil if not present.
+	Identifier     string           // optional; empty if not present.
+	Discriminator  Field            // optional; nil if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.
@@ -240,6 +246,9 @@ func (md *DICompositeType) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DICompositeType) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -357,6 +366,9 @@ func (md *DIDerivedType) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIDerivedType) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -447,6 +459,9 @@ func (md *DIEnumerator) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIEnumerator) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -503,6 +518,9 @@ func (md *DIExpression) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIExpression) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -630,6 +648,9 @@ func (md *DIGlobalVariable) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIGlobalVariable) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -724,6 +745,9 @@ func (md *DIGlobalVariableExpression) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIGlobalVariableExpression) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -782,6 +806,9 @@ func (md *DIImportedEntity) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIImportedEntity) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -849,6 +876,9 @@ func (md *DILabel) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DILabel) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -904,6 +934,9 @@ func (md *DILexicalBlock) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DILexicalBlock) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -964,6 +997,9 @@ func (md *DILexicalBlockFile) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DILexicalBlockFile) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1024,6 +1060,9 @@ func (md *DILocalVariable) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DILocalVariable) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1102,6 +1141,9 @@ func (md *DILocation) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DILocation) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1167,6 +1209,9 @@ func (md *DIMacro) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIMacro) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1226,6 +1271,9 @@ func (md *DIMacroFile) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIMacroFile) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1288,6 +1336,9 @@ func (md *DIModule) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIModule) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1350,6 +1401,9 @@ func (md *DINamespace) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DINamespace) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1410,6 +1464,9 @@ func (md *DIObjCProperty) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIObjCProperty) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1501,6 +1558,9 @@ func (md *DISubprogram) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DISubprogram) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1630,6 +1690,9 @@ func (md *DISubrange) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DISubrange) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1682,6 +1745,9 @@ func (md *DISubroutineType) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DISubroutineType) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1737,6 +1803,9 @@ func (md *DITemplateTypeParameter) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DITemplateTypeParameter) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1791,6 +1860,9 @@ func (md *DITemplateValueParameter) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DITemplateValueParameter) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}
@@ -1851,6 +1923,9 @@ func (md *GenericDINode) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *GenericDINode) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -727,8 +727,8 @@ type DIGlobalVariableExpression struct {
 	// (optional) Distinct.
 	Distinct bool
 
-	Var  Field         // required.
-	Expr *DIExpression // required.
+	Var  *DIGlobalVariable // required.
+	Expr *DIExpression     // required.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -1216,7 +1216,7 @@ type DIMacroFile struct {
 	Type  enum.DwarfMacinfo // optional; zero value if not present.
 	Line  int64             // optional; zero value if not present.
 	File  *DIFile           // required.
-	Nodes Field             // optional; nil if not present.
+	Nodes *Tuple            // optional; nil if not present.
 }
 
 // String returns the LLVM syntax representation of the specialized metadata node.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -1537,7 +1537,7 @@ type DISubprogram struct {
 	ThisAdjustment int64                // optional; zero value if not present.
 	Flags          enum.DIFlag          // optional.
 	IsOptimized    bool                 // optional; zero value if not present.
-	Unit           Field                // optional; nil if not present.
+	Unit           *DICompileUnit       // optional; nil if not present.
 	TemplateParams *Tuple               // optional; nil if not present.
 	Declaration    Field                // optional; nil if not present.
 	RetainedNodes  *Tuple               // optional; nil if not present.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -225,7 +225,7 @@ type DICompositeType struct {
 	Align          uint64         // optional; zero value if not present.
 	Offset         uint64         // optional; zero value if not present.
 	Flags          enum.DIFlag    // optional.
-	Elements       Field          // optional; nil if not present.
+	Elements       *Tuple         // optional; nil if not present.
 	RuntimeLang    enum.DwarfLang // optional; zero value if not present.
 	VtableHolder   Field          // optional; nil if not present.
 	TemplateParams *Tuple         // optional; nil if not present.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -228,7 +228,7 @@ type DICompositeType struct {
 	Elements       Field          // optional; nil if not present.
 	RuntimeLang    enum.DwarfLang // optional; zero value if not present.
 	VtableHolder   Field          // optional; nil if not present.
-	TemplateParams Field          // optional; nil if not present.
+	TemplateParams *Tuple         // optional; nil if not present.
 	Identifier     string         // optional; empty if not present.
 	Discriminator  Field          // optional; nil if not present.
 }
@@ -618,7 +618,7 @@ type DIGlobalVariable struct {
 	Type           Field   // optional; nil if not present.
 	IsLocal        bool    // optional; zero value if not present.
 	IsDefinition   bool    // optional; zero value if not present.
-	TemplateParams Field   // optional; nil if not present.
+	TemplateParams *Tuple  // optional; nil if not present.
 	Declaration    Field   // optional; nil if not present.
 	Align          uint64  // optional; zero value if not present.
 }
@@ -1488,7 +1488,7 @@ type DISubprogram struct {
 	Flags          enum.DIFlag          // optional.
 	IsOptimized    bool                 // optional; zero value if not present.
 	Unit           Field                // optional; nil if not present.
-	TemplateParams Field                // optional; nil if not present.
+	TemplateParams *Tuple               // optional; nil if not present.
 	Declaration    Field                // optional; nil if not present.
 	RetainedNodes  Field                // optional; nil if not present.
 	ThrownTypes    Field                // optional; nil if not present.

--- a/ir/metadata/specialized_metadata.go
+++ b/ir/metadata/specialized_metadata.go
@@ -78,7 +78,7 @@ type DICompileUnit struct {
 	MetadataID
 
 	Language              enum.DwarfLang     // required.
-	File                  Field              // required.
+	File                  *DIFile            // required.
 	Producer              string             // optional; empty if not present.
 	IsOptimized           bool               // optional; zero value if not present.
 	Flags                 string             // optional; empty if not present.
@@ -485,6 +485,9 @@ func (md *DIFile) String() string {
 
 // Ident returns the identifier associated with the specialized metadata node.
 func (md *DIFile) Ident() string {
+	if md == nil {
+		return "null"
+	}
 	if md.MetadataID != -1 {
 		return md.MetadataID.Ident()
 	}

--- a/ir/metadata/sumtypes.go
+++ b/ir/metadata/sumtypes.go
@@ -12,7 +12,28 @@ import "fmt"
 //    *metadata.Def            // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
 //    *metadata.DIExpression   // https://godoc.org/github.com/llir/llvm/ir/metadata#DIExpression
 type Node interface {
+	// Ident returns the identifier associated with the metadata node.
+	Ident() string
+}
+
+// Definition is a metadata definition.
+//
+// A Definition has one of the following underlying types.
+//
+//    *metadata.Def     // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
+//    metadata.MDNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#MDNode
+type Definition interface {
+	// String returns the LLVM syntax representation of the metadata.
 	fmt.Stringer
+	// Ident returns the identifier associated with the metadata definition.
+	Ident() string
+	// ID returns the ID of the metadata definition.
+	ID() int64
+	// SetID sets the ID of the metadata definition.
+	SetID(id int64)
+	// LLString returns the LLVM syntax representation of the metadata
+	// definition.
+	LLString() string
 }
 
 // MDNode is a metadata node.
@@ -23,7 +44,10 @@ type Node interface {
 //    *metadata.Def              // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
 //    metadata.SpecializedNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#SpecializedNode
 type MDNode interface {
-	fmt.Stringer
+	// Ident returns the identifier associated with the metadata node.
+	Ident() string
+	// LLString returns the LLVM syntax representation of the metadata node.
+	LLString() string
 }
 
 // Field is a metadata field.
@@ -33,6 +57,7 @@ type MDNode interface {
 //    *metadata.NullLit   // https://godoc.org/github.com/llir/llvm/ir/metadata#NullLit
 //    metadata.Metadata   // https://godoc.org/github.com/llir/llvm/ir/metadata#Metadata
 type Field interface {
+	// String returns the LLVM syntax representation of the metadata field.
 	fmt.Stringer
 }
 
@@ -67,7 +92,7 @@ type Field interface {
 //    *metadata.DITemplateValueParameter     // https://godoc.org/github.com/llir/llvm/ir/metadata#DITemplateValueParameter
 //    *metadata.GenericDINode                // https://godoc.org/github.com/llir/llvm/ir/metadata#GenericDINode
 type SpecializedNode interface {
-	fmt.Stringer
+	Definition
 }
 
 // FieldOrInt is a metadata field or integer.
@@ -77,7 +102,7 @@ type SpecializedNode interface {
 //    metadata.Field    // https://godoc.org/github.com/llir/llvm/ir/metadata#Field
 //    metadata.IntLit   // https://godoc.org/github.com/llir/llvm/ir/metadata#IntLit
 type FieldOrInt interface {
-	fmt.Stringer
+	Field
 }
 
 // DIExpressionField is a metadata DIExpression field.
@@ -107,5 +132,6 @@ func (UintLit) IsDIExpressionField() {}
 //    *metadata.Def              // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
 //    metadata.SpecializedNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#SpecializedNode
 type Metadata interface {
+	// String returns the LLVM syntax representation of the metadata.
 	fmt.Stringer
 }

--- a/ir/metadata/sumtypes.go
+++ b/ir/metadata/sumtypes.go
@@ -9,7 +9,7 @@ import "fmt"
 //
 // A Node has one of the following underlying types.
 //
-//    *metadata.Def            // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
+//    metadata.Definition      // https://godoc.org/github.com/llir/llvm/ir/metadata#Definition
 //    *metadata.DIExpression   // https://godoc.org/github.com/llir/llvm/ir/metadata#DIExpression
 type Node interface {
 	// Ident returns the identifier associated with the metadata node.
@@ -20,7 +20,6 @@ type Node interface {
 //
 // A Definition has one of the following underlying types.
 //
-//    *metadata.Def     // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
 //    metadata.MDNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#MDNode
 type Definition interface {
 	// String returns the LLVM syntax representation of the metadata.
@@ -34,6 +33,8 @@ type Definition interface {
 	// LLString returns the LLVM syntax representation of the metadata
 	// definition.
 	LLString() string
+	// SetDistinct specifies whether the metadata definition is dinstict.
+	SetDistinct(distinct bool)
 }
 
 // MDNode is a metadata node.
@@ -41,7 +42,7 @@ type Definition interface {
 // A MDNode has one of the following underlying types.
 //
 //    *metadata.Tuple            // https://godoc.org/github.com/llir/llvm/ir/metadata#Tuple
-//    *metadata.Def              // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
+//    metadata.Definition        // https://godoc.org/github.com/llir/llvm/ir/metadata#Definition
 //    metadata.SpecializedNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#SpecializedNode
 type MDNode interface {
 	// Ident returns the identifier associated with the metadata node.
@@ -129,7 +130,7 @@ func (UintLit) IsDIExpressionField() {}
 //    value.Value                // https://godoc.org/github.com/llir/llvm/ir/value#Value
 //    *metadata.String           // https://godoc.org/github.com/llir/llvm/ir/metadata#String
 //    *metadata.Tuple            // https://godoc.org/github.com/llir/llvm/ir/metadata#Tuple
-//    *metadata.Def              // https://godoc.org/github.com/llir/llvm/ir/metadata#Def
+//    metadata.Definition        // https://godoc.org/github.com/llir/llvm/ir/metadata#Definition
 //    metadata.SpecializedNode   // https://godoc.org/github.com/llir/llvm/ir/metadata#SpecializedNode
 type Metadata interface {
 	// String returns the LLVM syntax representation of the metadata.


### PR DESCRIPTION
Update NamedMetadataDefs to be a map from
metadata name to named metadata definition
instead of a slice.

Add metadata IDs to metadata definitions (i.e.
metadata tuple and specialized metadata nodes).

This is in preparation for a simplification of
the specialized metadata API, to make it possible
for users to access DWARF debug info fields
without having to use type assertions as often.

In particular, the main focus is to make life easier for
users of the metadata API, so they should not have to do
as many type assertions to reach the "real" data of Debug
Info specialized metadata nodes.