### PR TITLE
Add type checking to {bitcast,ptrtoint,inttoptr}

### DIFF
--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -146,6 +146,8 @@ func aggregateElemType(t types.Type, indices []uint64) types.Type {
 		return aggregateElemType(t.ElemType, indices[1:])
 	case *types.StructType:
 		return aggregateElemType(t.Fields[indices[0]], indices[1:])
+	case *types.PointerType:
+		return aggregateElemType(t.ElemType, indices[1:])
 	default:
 		panic(fmt.Errorf("support for aggregate type %T not yet implemented", t))
 	}

--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -92,6 +92,10 @@ type InstInsertValue struct {
 // NewInsertValue returns a new insertvalue instruction based on the given
 // aggregate value, element and indicies.
 func NewInsertValue(x, elem value.Value, indices ...uint64) *InstInsertValue {
+	elemType := aggregateElemType(x.Type(), indices)
+	if !elemType.Equal(elem.Type()) {
+		panic(fmt.Errorf("insertvalue elem type mismatch, expected %v, got %v", elemType, elem.Type()))
+	}
 	inst := &InstInsertValue{X: x, Elem: elem, Indices: indices}
 	// Compute type.
 	return inst

--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -98,6 +98,7 @@ func NewInsertValue(x, elem value.Value, indices ...uint64) *InstInsertValue {
 	}
 	inst := &InstInsertValue{X: x, Elem: elem, Indices: indices}
 	// Compute type.
+	inst.Type()
 	return inst
 }
 

--- a/ir/inst_conversion.go
+++ b/ir/inst_conversion.go
@@ -444,6 +444,12 @@ type InstPtrToInt struct {
 // NewPtrToInt returns a new ptrtoint instruction based on the given source
 // value and target type.
 func NewPtrToInt(from value.Value, to types.Type) *InstPtrToInt {
+	if _, isFromPointer := from.Type().(*types.PointerType); !isFromPointer {
+		panic(fmt.Errorf("invalid ptrtoint operand type; expected *types.PointerType, got \"from\": %T", from.Type()))
+	}
+	if _, isToInt := to.(*types.IntType); !isToInt {
+		panic(fmt.Errorf("invalid ptrtoint operand type; expected *types.IntType, got \"to\": %T", to))
+	}
 	return &InstPtrToInt{From: from, To: to}
 }
 
@@ -490,6 +496,12 @@ type InstIntToPtr struct {
 // NewIntToPtr returns a new inttoptr instruction based on the given source
 // value and target type.
 func NewIntToPtr(from value.Value, to types.Type) *InstIntToPtr {
+	if _, isFromInt := from.Type().(*types.IntType); !isFromInt {
+		panic(fmt.Errorf("invalid inttoptr operand type; expected *types.IntType, got \"from\": %T", from.Type()))
+	}
+	if _, isToPtr := to.(*types.PointerType); !isToPtr {
+		panic(fmt.Errorf("invalid inttoptr operand type; expected *types.PointerType, got \"to\": %T", to))
+	}
 	return &InstIntToPtr{From: from, To: to}
 }
 
@@ -536,6 +548,12 @@ type InstBitCast struct {
 // NewBitCast returns a new bitcast instruction based on the given source value
 // and target type.
 func NewBitCast(from value.Value, to types.Type) *InstBitCast {
+	if _, isFromPtr := from.Type().(*types.PointerType); !isFromPtr {
+		panic(fmt.Errorf("invalid bitcast operand type; expected *types.PointerType, got \"from\": %T", from.Type()))
+	}
+	if _, isToPtr := to.(*types.PointerType); !isToPtr {
+		panic(fmt.Errorf("invalid bitcast operand type; expected *types.PointerType, got \"to\": %T", to))
+	}
 	return &InstBitCast{From: from, To: to}
 }
 

--- a/ir/inst_conversion.go
+++ b/ir/inst_conversion.go
@@ -30,6 +30,11 @@ type InstTrunc struct {
 // NewTrunc returns a new trunc instruction based on the given source value and
 // target type.
 func NewTrunc(from value.Value, to types.Type) *InstTrunc {
+	fromSize := from.Type().(*types.IntType).BitSize
+	toSize := to.(*types.IntType).BitSize
+	if fromSize < toSize {
+		panic(fmt.Errorf("invalid trunc: from.BitSize < to.BitSize (%v < %v)", fromSize, toSize))
+	}
 	return &InstTrunc{From: from, To: to}
 }
 


### PR DESCRIPTION
As discussed in #65, having this sort of check can be useful for pinpointing bugs.

There may be use cases for using incomplete types and filling them in later. Those may be fulfilled by manually constructing values of the types.

There is precedent in the code for this kind of type checking.

This PR adds type checking to:

* insertvalue
* trunc
* bitcast
* ptrtoint
* inttoptr

I also made aggregateElemType support pointer types, and decided to include the fix to #67 in this PR, since it was trivial.

Closes #65.
Closes #67. (I have done `grep -A1 'Compute type'` and checked that all similar comments have an appropriate call - it looks like this was the only one).