### PR TITLE
Type check elem in insertvalue

### DIFF
--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -146,6 +146,8 @@ func aggregateElemType(t types.Type, indices []uint64) types.Type {
 		return aggregateElemType(t.ElemType, indices[1:])
 	case *types.StructType:
 		return aggregateElemType(t.Fields[indices[0]], indices[1:])
+	case *types.PointerType:
+		return aggregateElemType(t.ElemType, indices[1:])
 	default:
 		panic(fmt.Errorf("support for aggregate type %T not yet implemented", t))
 	}

--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -34,6 +34,7 @@ type InstExtractValue struct {
 func NewExtractValue(x value.Value, indices ...uint64) *InstExtractValue {
 	inst := &InstExtractValue{X: x, Indices: indices}
 	// Compute type.
+	inst.Type()
 	return inst
 }
 
@@ -98,6 +99,7 @@ func NewInsertValue(x, elem value.Value, indices ...uint64) *InstInsertValue {
 	}
 	inst := &InstInsertValue{X: x, Elem: elem, Indices: indices}
 	// Compute type.
+	inst.Type()
 	return inst
 }
 

--- a/ir/inst_aggregate.go
+++ b/ir/inst_aggregate.go
@@ -92,6 +92,10 @@ type InstInsertValue struct {
 // NewInsertValue returns a new insertvalue instruction based on the given
 // aggregate value, element and indicies.
 func NewInsertValue(x, elem value.Value, indices ...uint64) *InstInsertValue {
+	elemType := aggregateElemType(x.Type(), indices)
+	if !elemType.Equal(elem.Type()) {
+		panic(fmt.Errorf("insertvalue elem type mismatch, expected %v, got %v", elemType, elem.Type()))
+	}
 	inst := &InstInsertValue{X: x, Elem: elem, Indices: indices}
 	// Compute type.
 	return inst

--- a/ir/inst_aggregate_test.go
+++ b/ir/inst_aggregate_test.go
@@ -1,0 +1,46 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
+)
+
+func TestTypeCheckInstExtractValue(t *testing.T) {
+	structType := types.NewStruct(types.I32, types.I64)
+
+	// Should succeed.
+	var v value.Value = constant.NewUndef(structType)
+	v.String()
+	v = NewInsertValue(v, constant.NewInt(types.I32, 1), 0)
+	v.String()
+	v = NewInsertValue(v, constant.NewInt(types.I64, 1), 1)
+	v.String()
+
+	var panicErr error
+	func() {
+		defer func() { panicErr = recover().(error) }()
+		// Should panic because index 1 is I64, not I32.
+		v = NewInsertValue(v, constant.NewInt(types.I32, 1), 1)
+		t.Fatal("unreachable")
+	}()
+	expected := "insertvalue elem type mismatch, expected i64, got i32"
+	got := panicErr.Error()
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+
+	func() {
+		defer func() { panicErr = recover().(error) }()
+		// Should panic because index 0 is I32, not I64.
+		v = NewInsertValue(v, constant.NewInt(types.I64, 1), 0)
+		t.Fatal("unreachable")
+	}()
+	expected = "insertvalue elem type mismatch, expected i32, got i64"
+	got = panicErr.Error()
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
When inserting an element into an aggregate type, the type must match. Check it so that code doing this erroneously panics at the point of the mistake rather than producing ill-formed code. See discussion in #65.

Since #69 turned out to be more complicated than I first thought, I've broken out insertvalue into this PR.

Hopefully this is less complicated. I also added a simple test.

Also fixes #67.