### PR TITLE
ir: rename duplicate named functions(only when funciton in module)

### DIFF
--- a/ir/ir_test.go
+++ b/ir/ir_test.go
@@ -30,6 +30,21 @@ func TestModuleString(t *testing.T) {
 			},
 			want: "%foo = type { i32 }",
 		},
+		// duplicate named funcitons
+		{
+			in: func() *Module {
+				mod := NewModule()
+				mod.NewFunc("add", types.I64)
+				mod.NewFunc("add", types.I64)
+				mod.NewFunc("add", types.I64)
+				return mod
+			}(),
+			want: `declare i64 @add()
+
+declare i64 @add.1()
+
+declare i64 @add.2()`,
+		},
 	}
 	for _, g := range golden {
 		got := strings.TrimSpace(g.in.String())

--- a/ir/module.go
+++ b/ir/module.go
@@ -133,11 +133,22 @@ func (m *Module) String() string {
 	if len(m.Funcs) > 0 && buf.Len() > 0 {
 		buf.WriteString("\n")
 	}
+	// map function name to counter
+	funcCheckMap := make(map[string]uint64)
 	for i, f := range m.Funcs {
 		if i != 0 {
 			buf.WriteString("\n")
 		}
+		originName := f.Name()
+		count := funcCheckMap[originName]
+		// at first would be 0
+		if count > 0 {
+			newName := fmt.Sprintf("%s.%d", f.Name(), count)
+			f.SetName(newName)
+		}
+		funcCheckMap[originName]++
 		fmt.Fprintln(buf, f.LLString())
+		f.SetName(originName)
 	}
 	// Attribute group definitions.
 	if len(m.AttrGroupDefs) > 0 && buf.Len() > 0 {


### PR DESCRIPTION
for #75, let `*ir.Module` automatically rename duplicate named functions. Modify at module is because the major purpose is just for creating valid llvm-ir code.