### PR TITLE
travis: fix build for Go 1.13 (tip)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11"
+  - "1.12"
   - tip
 
 notifications:
@@ -20,7 +20,8 @@ before_script:
   - go get golang.org/x/tools/cmd/goimports
   - go get golang.org/x/lint/golint
   - go get github.com/mattn/goveralls
-  - go get github.com/golangci/golangci-lint/cmd/golangci-lint
+  # TODO: re-enable when https://github.com/golangci/golangci-lint/issues/595 is resolved.
+  #- go get github.com/golangci/golangci-lint/cmd/golangci-lint
   - wget https://raw.githubusercontent.com/mewmew/ci/master/ci_checks.sh
   - chmod +x ci_checks.sh
 

--- a/ir/inst_aggregate_test.go
+++ b/ir/inst_aggregate_test.go
@@ -13,11 +13,11 @@ func TestTypeCheckInstExtractValue(t *testing.T) {
 
 	// Should succeed.
 	var v value.Value = constant.NewUndef(structType)
-	v.String()
+	_ = v.String()
 	v = NewInsertValue(v, constant.NewInt(types.I32, 1), 0)
-	v.String()
+	_ = v.String()
 	v = NewInsertValue(v, constant.NewInt(types.I64, 1), 1)
-	v.String()
+	_ = v.String()
 
 	var panicErr error
 	func() {

--- a/ir/inst_conversion_test.go
+++ b/ir/inst_conversion_test.go
@@ -39,7 +39,7 @@ func TestTypeCheckTrunc(t *testing.T) {
 			func() {
 				defer func() { panicErr = recover().(error) }()
 				trunc := NewTrunc(zeroVal, c.toTyp)
-				trunc.String()
+				_ = trunc.String()
 				panic(errOK)
 			}()
 			got := panicErr.Error()


### PR DESCRIPTION
Bump stable Go version to 1.12 and uncomment `golangci-lint`.

Re-enable golangci-lint once golangci/golangci-lint#595 is resolved.