### PR TITLE
(#111) handle u0x/s0x prefix

### DIFF
--- a/asm/helper.go
+++ b/asm/helper.go
@@ -166,7 +166,20 @@ func boolLit(old ast.BoolLit) bool {
 // unsigned integer literal.
 func uintLit(old ast.UintLit) uint64 {
 	text := old.Text()
-	x, err := strconv.ParseUint(text, 10, 64)
+	var x uint64
+	var err error
+	switch {
+	case strings.HasPrefix(text, "u0x"):
+		text = text[len("u0x"):]
+		x, err = strconv.ParseUint(text, 16, 64)
+	case strings.HasPrefix(text, "s0x"):
+		text = text[len("s0x"):]
+		// TODO: figure out how to handle negative values.
+		// The problem at here was we should return an int64 but since signature parse as uint64
+		x, err = strconv.ParseUint(text, 16, 64)
+	default:
+		x, err = strconv.ParseUint(text, 10, 64)
+	}
 	if err != nil {
 		panic(fmt.Errorf("unable to parse unsigned integer literal %q; %v", text, err))
 	}


### PR DESCRIPTION
I'm trying to fix the literal shows at https://github.com/llir/llvm/issues/111#issuecomment-562811343

Please take the test by enabling full test cases since I didn't know how to do the test in #111 described. And for `out of range` issue I think it's a big topic, in the code, there are many `uint64` are directly used. Introduce `uint128` and unify them as only have `uint` is not as easy as I originally thought. It seems like needs another issue for it.

I thought a probable solution is to define the following algebra data type:

```hs
data UInt =
  UInt128 Uint128
  | UInt64 Uint64
```

and can be represented in Go like:

```go
type UInt interface {
  impl() UInt
}

type UInt128 struct {
  UInt
  value [2]uint64
}
type UInt64 struct {
  UInt
  value uint64
}
```

Of course, the `Add`, `Sub`, `Mul` and `Div` should be defined but here just ignore them. Then update the signature would be a big deal.