### PR TITLE
ir: use value.Value for operands of instructions and terminators

### DIFF
--- a/asm/term.go
+++ b/asm/term.go
@@ -305,7 +305,7 @@ func (fgen *funcGen) irIndirectBrTerm(new ir.Terminator, old *ast.IndirectBrTerm
 	term.Addr = addr
 	// Valid targets.
 	if oldValidTargets := old.ValidTargets(); len(oldValidTargets) > 0 {
-		term.ValidTargets = make([]*ir.Block, len(oldValidTargets))
+		term.ValidTargets = make([]value.Value, len(oldValidTargets))
 		for i, oldValidTarget := range oldValidTargets {
 			validTarget, err := fgen.irBlock(oldValidTarget)
 			if err != nil {
@@ -568,7 +568,7 @@ func (fgen *funcGen) irCatchSwitchTerm(new ir.Terminator, old *ast.CatchSwitchTe
 	term.Scope = scope
 	// Exception handlers.
 	if oldHandlers := old.Handlers().Labels(); len(oldHandlers) > 0 {
-		term.Handlers = make([]*ir.Block, len(oldHandlers))
+		term.Handlers = make([]value.Value, len(oldHandlers))
 		for i, oldHandler := range oldHandlers {
 			handler, err := fgen.irBlock(oldHandler)
 			if err != nil {

--- a/ir/helper.go
+++ b/ir/helper.go
@@ -138,7 +138,6 @@ func (d Dereferenceable) String() string {
 // ExceptionScope is an exception scope.
 type ExceptionScope interface {
 	value.Value
-	//isExceptionScope()
 }
 
 // FuncAttribute is a function attribute.
@@ -345,9 +344,6 @@ type ReturnAttribute interface {
 //    ir.UnwindToCaller
 type UnwindTarget interface {
 	value.Value
-	// isUnwindTarget ensures that only unwind targets can be assigned to the
-	// ir.UnwindTarget interface.
-	//isUnwindTarget()
 }
 
 // UnwindToCaller specifies the caller as an unwind target.

--- a/ir/helper.go
+++ b/ir/helper.go
@@ -335,6 +335,8 @@ type ReturnAttribute interface {
 	IsReturnAttribute()
 }
 
+// TODO: figure out definition of UnwindTarget.
+
 // UnwindTarget is an unwind target.
 //
 // An UnwindTarget has one of the following underlying types.
@@ -342,9 +344,10 @@ type ReturnAttribute interface {
 //    *ir.Block
 //    ir.UnwindToCaller
 type UnwindTarget interface {
+	value.Value
 	// isUnwindTarget ensures that only unwind targets can be assigned to the
 	// ir.UnwindTarget interface.
-	isUnwindTarget()
+	//isUnwindTarget()
 }
 
 // UnwindToCaller specifies the caller as an unwind target.

--- a/ir/inst_other.go
+++ b/ir/inst_other.go
@@ -212,7 +212,7 @@ type Incoming struct {
 	// Incoming value.
 	X value.Value
 	// Predecessor basic block of the incoming value.
-	Pred *Block
+	Pred value.Value // *ir.Block
 }
 
 // NewIncoming returns a new incoming value based on the given value and

--- a/ir/inst_other.go
+++ b/ir/inst_other.go
@@ -558,7 +558,8 @@ type InstCatchPad struct {
 	// Name of local variable associated with the result.
 	LocalIdent
 	// Exception scope.
-	Scope *TermCatchSwitch // TODO: rename to From? rename to Within?
+	// TODO: rename to From? rename to Within?
+	Scope value.Value // *ir.TermCatchSwitch
 	// Exception arguments.
 	//
 	// Arg has one of the following underlying types:
@@ -616,7 +617,8 @@ type InstCleanupPad struct {
 	// Name of local variable associated with the result.
 	LocalIdent
 	// Exception scope.
-	Scope ExceptionScope // TODO: rename to Parent? rename to From?
+	// TODO: rename to Parent? rename to From?
+	Scope value.Value // ExceptionScope
 	// Exception arguments.
 	//
 	// Arg has one of the following underlying types:

--- a/ir/inst_other.go
+++ b/ir/inst_other.go
@@ -618,7 +618,7 @@ type InstCleanupPad struct {
 	LocalIdent
 	// Exception scope.
 	// TODO: rename to Parent? rename to From?
-	Scope value.Value // ExceptionScope
+	Scope value.Value // ir.ExceptionScope
 	// Exception arguments.
 	//
 	// Arg has one of the following underlying types:

--- a/ir/sumtype.go
+++ b/ir/sumtype.go
@@ -161,16 +161,6 @@ func (Dereferenceable) IsReturnAttribute() {}
 
 // === [ ir.UnwindTarget ] =====================================================
 
-// isUnwindTarget ensures that only unwind targets can be assigned to the
-// ir.UnwindTarget interface.
-func (*Block) isUnwindTarget() {}
-
-// isUnwindTarget ensures that only unwind targets can be assigned to the
-// ir.UnwindTarget interface.
-func (UnwindToCaller) isUnwindTarget() {}
-
-// === [ ir.UnwindTarget ] =====================================================
-
 // ir.UnwindTarget = *ir.Block | ir.UnwindToCaller
 
 // TODO: figure out how to handle UnwindToCaller.Type.

--- a/ir/sumtype.go
+++ b/ir/sumtype.go
@@ -1,5 +1,9 @@
 package ir
 
+import (
+	"github.com/llir/llvm/ir/types"
+)
+
 // === [ constant.Constant ] ===================================================
 
 // IsConstant ensures that only constants can be assigned to the
@@ -164,3 +168,26 @@ func (*Block) isUnwindTarget() {}
 // isUnwindTarget ensures that only unwind targets can be assigned to the
 // ir.UnwindTarget interface.
 func (UnwindToCaller) isUnwindTarget() {}
+
+// === [ ir.UnwindTarget ] =====================================================
+
+// isUnwindTarget ensures that only unwind targets can be assigned to the
+// ir.UnwindTarget interface.
+//func (*Block) isUnwindTarget() {}
+
+// isUnwindTarget ensures that only unwind targets can be assigned to the
+// ir.UnwindTarget interface.
+//func (UnwindToCaller) isUnwindTarget() {}
+
+// TODO: figure out how to handle UnwindToCaller.Type.
+
+// Type returns the type of the value.
+func (UnwindToCaller) Type() types.Type {
+	// Type is a dummy method for UnwindToCaller to implement value.Value.
+	panic("UnwindToCaller does not have a type")
+}
+
+// Ident returns the identifier associated with the value.
+func (u UnwindToCaller) Ident() string {
+	return u.String()
+}

--- a/ir/sumtype.go
+++ b/ir/sumtype.go
@@ -171,13 +171,7 @@ func (UnwindToCaller) isUnwindTarget() {}
 
 // === [ ir.UnwindTarget ] =====================================================
 
-// isUnwindTarget ensures that only unwind targets can be assigned to the
-// ir.UnwindTarget interface.
-//func (*Block) isUnwindTarget() {}
-
-// isUnwindTarget ensures that only unwind targets can be assigned to the
-// ir.UnwindTarget interface.
-//func (UnwindToCaller) isUnwindTarget() {}
+// ir.UnwindTarget = *ir.Block | ir.UnwindToCaller
 
 // TODO: figure out how to handle UnwindToCaller.Type.
 


### PR DESCRIPTION
This PR changes the type of operands (and basic block targets) of instructions and terminators to use `value.Value` instead of their sometimes more specific type.

The benefit of this change is that it enables a very powerful operand use-tracking and operand value replacement API (see #42).
    
**Note**: this PR was initially intended for the v0.4 release. However, it could make sense to have this rather invasive API change land earlier, as otherwise we would break v0.3 uses unnecessarily.

Of course, we must first reach a consensus on whether this is the right approach to take for the API of `llir/llvm/ir`.

I have tried to consider the benefits (enables a powerful operands API) and drawbacks (less specific types of operands), and personally I think the change is worth it.

I would be very interested in getting feedback on this. And I'd also be glad to postpone this change to the v0.4 release if we need more time to discuss. As mentioned, the benefit of making this change early is that we will want to enable stability for v0.3 users, at least where we can expect future API breakage such as this one.

Fixes #50.

cc: @pwaller, @dannypsnl

P.S. I'll submit a follow-up PR to `llir/irutil` which includes a draft of what a instruction and terminator operand tracking API may look like.

Note, this change would enable the stronger operand tracking API, were we can also update those values since the operand tracking would operate on `*value.Value`. This was anticipated by @pwaller, and outlined in the following comment.

By @pwaller in https://github.com/llir/llvm/issues/42#issue-383892282
> I note that Operands() could almost return pointers to values, so that the references were mutable. However, this is broken. The only reason it is broken that I can find is the Scope field on InstCatchPad and InstCleanupPad. I think if we want to be able to obtain mutable references to Operands, those fields should become of types value.Value. I guess there are pros and cons to that. But if you want mutable references to operands I think the alternatives are going to be much uglier.