### PR TITLE
ir/constant: output int const in hex notation if more readable

### DIFF
--- a/ir/constant/const_int.go
+++ b/ir/constant/const_int.go
@@ -145,7 +145,7 @@ func (c *Int) Ident() string {
 // hexEntropy returns the entropy of x when encoded in hexadecimal notation. The
 // entropy is in range (0.0, 1.0] and is determined by the number of unique hex
 // digits required to represent x in hexadecimal notation divided by the total
-// number of hex digits, ignoring prefix.
+// number of hex digits ignoring prefix (capped by base 16).
 //
 // For instance, the hexadecimal value 0x80000000 (2147483648 in decimal)
 // requires two unique hex digits to be represented in hexadecimal notation,
@@ -169,7 +169,7 @@ func hexEntropy(x *big.Int) float64 {
 // decimalEntropy returns the entropy of x when encoded in decimal notation. The
 // entropy is in range (0.0, 1.0] and is determined by the number of unique
 // decimal digits required to represent x in decimal notation divided by the
-// total number of digits.
+// total number of digits (capped by base 10).
 //
 // For instance, the decimal value 2147483648 (0x80000000 in hex) requires seven
 // unique decimal digits to be represented in decimal notation; namely '1', '2',
@@ -198,7 +198,7 @@ func decimalEntropy(x *big.Int) float64 {
 // intEntropy returns the entropy of x when encoded in base notation. Base must
 // be between 2 and 62, inclusive. The entropy is in range (0.0, 1.0] and is
 // determined by the number of unique digits required to represent x in base
-// notation divided by the total number of digits.
+// notation divided by the total number of digits (capped by base).
 func intEntropy(x *big.Int, base int) float64 {
 	if base < 2 || base > 62 {
 		panic(fmt.Errorf("invalid base; expected 2 <= base <= 62, got %d", base))
@@ -217,13 +217,17 @@ func intEntropy(x *big.Int, base int) float64 {
 		digits[d] = true
 	}
 	// Count unique digits.
-	entropy := 0
+	uniqueDigits := 0
 	for i := 0; i < base; i++ {
 		if digits[i] {
-			entropy++
+			uniqueDigits++
 		}
 	}
-	return float64(entropy) / float64(len(s))
+	length := len(s)
+	if length > base {
+		length = base
+	}
+	return float64(uniqueDigits) / float64(length)
 }
 
 // digitValue returns the integer value of the given digit byte. As defined by

--- a/ir/constant/const_int.go
+++ b/ir/constant/const_int.go
@@ -171,13 +171,13 @@ func (c *Int) Ident() string {
 //    maxHexEntropy = 0.43   length == 7 (3/7)
 //    maxHexEntropy = 0.38   length == 8 (3/8)
 //    maxHexEntropy = 0.34   length == 9 (3/9)
-//    maxHexEntropy = 0.4    length == 10 (3/10)
+//    maxHexEntropy = 0.3    length == 10 (3/10)
 //    maxHexEntropy = 0.37   length == 11 (4/11)
 //    maxHexEntropy = 0.34   length == 12 (4/12)
-//    maxHexEntropy = 0.39   length == 13 (4/13)
-//    maxHexEntropy = 0.36   length == 14 (4/14)
-//    maxHexEntropy = 0.34   length == 15 (4/15)
-//    maxHexEntropy = 0.38   length >= 16 (4/16)
+//    maxHexEntropy = 0.31   length == 13 (4/13)
+//    maxHexEntropy = 0.29   length == 14 (4/14)
+//    maxHexEntropy = 0.27   length == 15 (4/15)
+//    maxHexEntropy = 0.25   length >= 16 (4/16)
 func calcMaxHexEntropy(length int) float64 {
 	if length > 16 {
 		length = 16

--- a/ir/constant/const_int.go
+++ b/ir/constant/const_int.go
@@ -132,7 +132,7 @@ func (c *Int) Ident() string {
 
 	// Minimum difference between entropy of decimal and hexadecimal notation to
 	// output x in hexadecimal notation.
-	const minEntropyDiff = 0.3
+	const minEntropyDiff = 0.2
 	// Maximum allowed entropy of hexadecimal notation to output x in hexadecimal
 	// notation.
 	//
@@ -145,12 +145,14 @@ func (c *Int) Ident() string {
 	// improve readability. Thus we add an upper bound on the hexadecimal entropy,
 	// and if the entropy is above this bound, output in decimal notation
 	// instead.
-	maxHexEntropy := calcMaxHexEntropy(len(c.X.Text(16)))
+	hexLength := len(c.X.Text(16))
+	maxHexEntropy := calcMaxHexEntropy(hexLength)
 	threshold := big.NewInt(0x1000) // 4096
-	// Check entropy if x is >= 0x1000.
+	// Check entropy if x >= 0x1000.
 	if c.X.Cmp(threshold) >= 0 {
 		hexentropy := hexEntropy(c.X)
-		if hexentropy <= maxHexEntropy && decimalEntropy(c.X) >= hexentropy+minEntropyDiff {
+		decentropy := decimalEntropy(c.X)
+		if hexentropy <= maxHexEntropy + 0.01 && decentropy >= hexentropy+minEntropyDiff {
 			return "u0x" + strings.ToUpper(c.X.Text(16))
 		}
 	}
@@ -169,45 +171,27 @@ func (c *Int) Ident() string {
 //    maxHexEntropy = 0.43   length == 7 (3/7)
 //    maxHexEntropy = 0.38   length == 8 (3/8)
 //    maxHexEntropy = 0.34   length == 9 (3/9)
-//    maxHexEntropy = 0.4    length == 10 (4/10)
+//    maxHexEntropy = 0.4    length == 10 (3/10)
 //    maxHexEntropy = 0.37   length == 11 (4/11)
 //    maxHexEntropy = 0.34   length == 12 (4/12)
-//    maxHexEntropy = 0.39   length == 13 (5/13)
-//    maxHexEntropy = 0.36   length == 14 (5/14)
-//    maxHexEntropy = 0.34   length == 15 (5/15)
-//    maxHexEntropy = 0.38   length >= 16 (6/16)
+//    maxHexEntropy = 0.39   length == 13 (4/13)
+//    maxHexEntropy = 0.36   length == 14 (4/14)
+//    maxHexEntropy = 0.34   length == 15 (4/15)
+//    maxHexEntropy = 0.38   length >= 16 (4/16)
 func calcMaxHexEntropy(length int) float64 {
-	if length < 4 {
-		return 0
+	if length > 16 {
+		length = 16
 	}
-	switch length {
-	case 4:
-		return 2.0 / 4.0
-	case 5:
-		return 2.0 / 5.0
-	case 6:
-		return 2.0 / 6.0
-	case 7:
-		return 3.0 / 7.0
-	case 8:
-		return 3.0 / 8.0
-	case 9:
-		return 3.0 / 9.0
-	case 10:
-		return 4.0 / 10.0
-	case 11:
-		return 4.0 / 11.0
-	case 12:
-		return 4.0 / 12.0
-	case 13:
-		return 5.0 / 13.0
-	case 14:
-		return 5.0 / 14.0
-	case 15:
-		return 5.0 / 15.0
-	// length >= 16
+	switch {
+	case length < 4:
+		return 0
+	case 4 <= length && length <= 6:
+		return 2.0 / float64(length)
+	case 7 <= length && length <= 10:
+		return 3.0 / float64(length)
+	// length >= 11
 	default:
-		return 6.0 / 16.0
+		return 4.0 / float64(length)
 	}
 }
 

--- a/ir/constant/const_int.go
+++ b/ir/constant/const_int.go
@@ -127,5 +127,98 @@ func (c *Int) Ident() string {
 			panic(fmt.Errorf("invalid integer value of boolean type; expected 0 or 1, got %d", x))
 		}
 	}
+	// Output x in hexadecimal notation if x is positive, greater than or equal to
+	// 1000 and require less unique digits to be represented in hexadeciaml
+	// notation than decimal notation.
+	threashold := big.NewInt(1000)
+	if c.X.Cmp(threashold) >= 0 {
+		// Check entropy if x is >= 1000.
+		if decimalEntropy(c.X) > hexEntropy(c.X) {
+			return "u0x" + strings.ToUpper(c.X.Text(16))
+		}
+	}
 	return c.X.String()
+}
+
+// ### [ Helper functions ] ####################################################
+
+// hexEntropy returns the number of unique hex digits required to represent x in
+// hexadecimal notation.
+//
+// For instance, the hexadecimal value 0x80000000 (2147483648 in decimal)
+// requires two unique hex digits to be represented in hexadecimal notation,
+// ignoring prefix; namely '0' and '8'.
+//
+// Hex digits of 0x80000000:
+//    0 0 0 0 0 0 0
+//    8
+func hexEntropy(x *big.Int) int {
+	const base = 16
+	return intEntropy(x, base)
+}
+
+// decimalEntropy returns the number of unique decimal digits required to represent
+// x in decimal notation.
+//
+// For instance, the decimal value 2147483648 (0x80000000 in hex) requires seven
+// unique decimal digits to be represented in decimal notation; namely '1', '2',
+// '3', '4', '6', '7' and '8'.
+//
+// Decimal digits of 2147483648:
+//    1
+//    2
+//    3
+//    4 4 4
+//    6
+//    7
+//    8 8
+func decimalEntropy(x *big.Int) int {
+	const base = 10
+	return intEntropy(x, base)
+}
+
+// intEntropy returns the number of unique digits required to represent x in the
+// given base notation. Base must be between 2 and 62, inclusive.
+func intEntropy(x *big.Int, base int) int {
+	if base < 2 || base > 62 {
+		panic(fmt.Errorf("invalid base; expected 2 <= base <= 62, got %d", base))
+	}
+	const maxBase = 62
+	var digits [maxBase]bool
+	s := x.Text(base)
+	// Locate unique digits.
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b == '-' {
+			// skip sign.
+			continue
+		}
+		d := digitValue(b)
+		digits[d] = true
+	}
+	// Count unique digits.
+	entropy := 0
+	for i := 0; i < base; i++ {
+		if digits[i] {
+			entropy++
+		}
+	}
+	return entropy
+}
+
+// digitValue returns the integer value of the given digit byte. As defined by
+// *big.Int.Text, the digit uses the lower-case letters 'a' to 'z' for digit
+// values 10 to 35, and the upper-case letters 'A' to 'Z' for digit values 36 to
+// 61.
+func digitValue(b byte) int {
+	switch {
+	case '0' <= b && b <= '9':
+		return 0 + int(b-'0')
+	case 'a' <= b && b <= 'z':
+		return 10 + int(b-'a')
+	case 'A' <= b && b <= 'Z':
+		return 36 + int(b-'A')
+	default:
+		panic(fmt.Errorf("invalid digit byte; expected [0-9a-zA-Z], got %#U", b))
+	}
 }

--- a/ir/constant/const_int_test.go
+++ b/ir/constant/const_int_test.go
@@ -1,0 +1,40 @@
+package constant
+
+import (
+	"testing"
+
+	"github.com/llir/llvm/ir/types"
+)
+
+func TestIntIdent(t *testing.T) {
+	golden := []struct {
+		in   string
+		want string
+	}{
+		// integers < 1000 are always represented in decimal notation.
+		{in: "100", want: "100"},
+		{in: "256", want: "256"},
+		// integers >= 1000 are represented in hexadecimal notation if lower
+		// entropy than decimal notation.
+		{in: "2147483648", want: "u0x80000000"},
+		{in: "9218868437227405312", want: "u0x7FF0000000000000"},
+		{in: "1000000000000000000", want: "1000000000000000000"}, // hex would be u0xDE0B6B3A7640000
+		// negative integers are always represented in decimal notation.
+		{in: "-100", want: "-100"},
+		{in: "-256", want: "-256"},
+		{in: "-9218868437227405312", want: "-9218868437227405312"},
+		{in: "-1000000000000000000", want: "-1000000000000000000"},
+	}
+	for _, g := range golden {
+		c, err := NewIntFromString(types.I64, g.in)
+		if err != nil {
+			t.Errorf("unable to parse integer literal %q; %v", g.in, err)
+			continue
+		}
+		got := c.Ident()
+		if g.want != got {
+			t.Errorf("integer constant string mismatch; expected %q, got %q", g.want, got)
+			continue
+		}
+	}
+}

--- a/ir/constant/const_int_test.go
+++ b/ir/constant/const_int_test.go
@@ -11,11 +11,14 @@ func TestIntIdent(t *testing.T) {
 		in   string
 		want string
 	}{
-		// integers < 1000 are always represented in decimal notation.
+		// integers < 0x1000 are always represented in decimal notation.
 		{in: "100", want: "100"},
 		{in: "256", want: "256"},
-		// integers >= 1000 are represented in hexadecimal notation if lower
+		{in: "1000", want: "1000"},
+		{in: "4095", want: "4095"},
+		// integers >= 0x1000 are represented in hexadecimal notation if lower
 		// entropy than decimal notation.
+		{in: "4096", want: "u0x1000"},
 		{in: "2147483648", want: "u0x80000000"},
 		{in: "9218868437227405312", want: "u0x7FF0000000000000"},
 		{in: "1000000000000000000", want: "1000000000000000000"}, // hex would be u0xDE0B6B3A7640000


### PR DESCRIPTION
To improve readability of integer constants in LLVM IR output, a notion
of "low entropy" is used to determine whether to output integer
constants in decimal or hexadecimal notation.

The main idea is to check how many unique digits are required for each
representation and use the notation (hex or decimal) that requires the
least.

To illustrate this idea, here are a few examples from before and after
this commit.

Before: 2147483648
After:  u0x80000000

Before: 9218868437227405312
After:  u0x7FF0000000000000

For now, we have a threshold at 1000, so integer constants below 1000
are always represented in decimal notation. This includes negative
integer values.

Fixes #125.