### PR TITLE
(#118) give unnamed globals ID before checking redefined

### DIFF
--- a/asm/asm_test.go
+++ b/asm/asm_test.go
@@ -341,6 +341,9 @@ func TestParseFile(t *testing.T) {
 		{path: "../testdata/llvm/test/Bitcode/callbr.ll"},
 		{path: "../testdata/llvm/test/Bitcode/disubrange.ll"},
 
+		// LLVM test/CodeGen.
+		{path: "../testdata/llvm/test/CodeGen/X86/extractps.ll"},
+
 		// LLVM test/DebugInfo/Generic.
 		{path: "../testdata/llvm/test/DebugInfo/Generic/constant-pointers.ll"},
 		{path: "../testdata/llvm/test/DebugInfo/Generic/debug-info-enum.ll"},

--- a/asm/module.go
+++ b/asm/module.go
@@ -15,6 +15,7 @@ import (
 
 // indexTopLevelEntities indexes the AST top-level entities of the given module.
 func (gen *generator) indexTopLevelEntities(old *ast.Module) error {
+	id := int64(0)
 	// 1. Index AST top-level entities.
 	for _, entity := range old.TopLevelEntities() {
 		switch entity := entity.(type) {
@@ -43,28 +44,28 @@ func (gen *generator) indexTopLevelEntities(old *ast.Module) error {
 			}
 			gen.old.comdatDefs[name] = entity
 		case *ast.GlobalDecl:
-			ident := globalIdent(entity.Name())
+			ident := gen.giveUnnamedIdentID(globalIdent(entity.Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.IndirectSymbolDef:
-			ident := globalIdent(entity.Name())
+			ident := gen.giveUnnamedIdentID(globalIdent(entity.Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.FuncDecl:
-			ident := globalIdent(entity.Header().Name())
+			ident := gen.giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.FuncDef:
-			ident := globalIdent(entity.Header().Name())
+			ident := gen.giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
@@ -96,6 +97,16 @@ func (gen *generator) indexTopLevelEntities(old *ast.Module) error {
 		}
 	}
 	return nil
+}
+
+// giveUnnamedIdentID give unnamed variable ID to ensure no conflict with others unnamed variables
+func (gen *generator) giveUnnamedIdentID(ident ir.GlobalIdent, id *int64) ir.GlobalIdent {
+	newIdent := ident
+	if newIdent.IsUnnamed() {
+		newIdent.SetID(*id)
+		*id = *id + 1
+	}
+	return newIdent
 }
 
 // === [ Create and index IR ] =================================================

--- a/asm/module.go
+++ b/asm/module.go
@@ -44,28 +44,28 @@ func (gen *generator) indexTopLevelEntities(old *ast.Module) error {
 			}
 			gen.old.comdatDefs[name] = entity
 		case *ast.GlobalDecl:
-			ident := gen.giveUnnamedIdentID(globalIdent(entity.Name()), &id)
+			ident := giveUnnamedIdentID(globalIdent(entity.Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.IndirectSymbolDef:
-			ident := gen.giveUnnamedIdentID(globalIdent(entity.Name()), &id)
+			ident := giveUnnamedIdentID(globalIdent(entity.Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.FuncDecl:
-			ident := gen.giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
+			ident := giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
 			gen.old.globals[ident] = entity
 			gen.old.globalOrder = append(gen.old.globalOrder, ident)
 		case *ast.FuncDef:
-			ident := gen.giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
+			ident := giveUnnamedIdentID(globalIdent(entity.Header().Name()), &id)
 			if prev, ok := gen.old.globals[ident]; ok {
 				return errors.Errorf("global identifier %q already present; prev `%s`, new `%s`", ident.Ident(), text(prev), text(entity))
 			}
@@ -100,13 +100,12 @@ func (gen *generator) indexTopLevelEntities(old *ast.Module) error {
 }
 
 // giveUnnamedIdentID give unnamed variable ID to ensure no conflict with others unnamed variables
-func (gen *generator) giveUnnamedIdentID(ident ir.GlobalIdent, id *int64) ir.GlobalIdent {
-	newIdent := ident
-	if newIdent.IsUnnamed() {
-		newIdent.SetID(*id)
-		*id = *id + 1
+func giveUnnamedIdentID(ident ir.GlobalIdent, id *int64) ir.GlobalIdent {
+	if ident.IsUnnamed() {
+		ident.SetID(*id)
+		*id++
 	}
-	return newIdent
+	return ident
 }
 
 // === [ Create and index IR ] =================================================


### PR DESCRIPTION
Sorry for that didn't use the solution mentioned in the issue, I found `globals` was a map unlike local variables were stored in several slices, so the next unnamed identifier would keep overriding previous value. To solve this I have to update the identifier before store it, and to avoid the default value of ID field `0` made checking code feel `@0` already be taken, eventually, I give identifier ID before checking redefined. 