### PR TITLE
(#128) new calling conventions

### DIFF
--- a/asm/enum/callingconv_string2enum.go
+++ b/asm/enum/callingconv_string2enum.go
@@ -25,6 +25,7 @@ func _() {
 	_ = x[enum.CallingConvSwift-16]
 	_ = x[enum.CallingConvCXXFastTLS-17]
 	_ = x[enum.CallingConvTail-18]
+	_ = x[enum.CallingConvCFGuardCheck-19]
 	_ = x[enum.CallingConvX86StdCall-64]
 	_ = x[enum.CallingConvX86FastCall-65]
 	_ = x[enum.CallingConvARM_APCS-66]
@@ -62,14 +63,14 @@ func _() {
 
 const (
 	_CallingConv_name_0 = "noneccc"
-	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcc"
+	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcccfguard_checkcc"
 	_CallingConv_name_2 = "x86_stdcallccx86_fastcallccarm_apcsccarm_aapcsccarm_aapcs_vfpccmsp430_intrccx86_thiscallccptx_kernelptx_device"
 	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcsaarch64_sve_vector_pcs"
 )
 
 var (
 	_CallingConv_index_0 = [...]uint8{0, 4, 7}
-	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97}
+	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97, 112}
 	_CallingConv_index_2 = [...]uint8{0, 13, 27, 37, 48, 63, 76, 90, 100, 110}
 	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233, 255}
 )

--- a/asm/enum/callingconv_string2enum.go
+++ b/asm/enum/callingconv_string2enum.go
@@ -24,6 +24,7 @@ func _() {
 	_ = x[enum.CallingConvPreserveAll-15]
 	_ = x[enum.CallingConvSwift-16]
 	_ = x[enum.CallingConvCXXFastTLS-17]
+	_ = x[enum.CallingConvTail-18]
 	_ = x[enum.CallingConvX86StdCall-64]
 	_ = x[enum.CallingConvX86FastCall-65]
 	_ = x[enum.CallingConvARM_APCS-66]
@@ -56,20 +57,21 @@ func _() {
 	_ = x[enum.CallingConvAMDGPU_LS-95]
 	_ = x[enum.CallingConvAMDGPU_ES-96]
 	_ = x[enum.CallingConvAArch64VectorCall-97]
+	_ = x[enum.CallingConvAArch64SVEVectorCall-98]
 }
 
 const (
 	_CallingConv_name_0 = "noneccc"
-	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscc"
+	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcc"
 	_CallingConv_name_2 = "x86_stdcallccx86_fastcallccarm_apcsccarm_aapcsccarm_aapcs_vfpccmsp430_intrccx86_thiscallccptx_kernelptx_device"
-	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcs"
+	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcsaarch64_sve_vector_pcs"
 )
 
 var (
 	_CallingConv_index_0 = [...]uint8{0, 4, 7}
-	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91}
+	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97}
 	_CallingConv_index_2 = [...]uint8{0, 13, 27, 37, 48, 63, 76, 90, 100, 110}
-	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233}
+	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233, 255}
 )
 
 // CallingConvFromString returns the CallingConv enum corresponding to s.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/google/go-cmp v0.3.1
 	github.com/kr/pretty v0.1.0
-	github.com/llir/ll v0.0.0-20200422105243-95dd5429938b
+	github.com/llir/ll v0.0.0-20200425014433-60cd8feecf92
 	github.com/mewmew/float v0.0.0-20191226120903-16bbe2fdd85e
 	github.com/pkg/errors v0.8.1
 	golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/llir/ll v0.0.0-20200414154635-a942fd56e775 h1:htltNQ09aljaA4owdZv203t
 github.com/llir/ll v0.0.0-20200414154635-a942fd56e775/go.mod h1:8W5HJz80PitAyPZUpOcljQxTu6LD5YKW1URTo+OjVoc=
 github.com/llir/ll v0.0.0-20200422105243-95dd5429938b h1:hibVlGr1GJCuii5UYS9+deM/pw21OP5M1aStGuAIF28=
 github.com/llir/ll v0.0.0-20200422105243-95dd5429938b/go.mod h1:8W5HJz80PitAyPZUpOcljQxTu6LD5YKW1URTo+OjVoc=
+github.com/llir/ll v0.0.0-20200425014433-60cd8feecf92 h1:46SWNHwNB1dvOK+9gO3TENanWN9ICNCXvt4uYAQh8aw=
+github.com/llir/ll v0.0.0-20200425014433-60cd8feecf92/go.mod h1:8W5HJz80PitAyPZUpOcljQxTu6LD5YKW1URTo+OjVoc=
 github.com/mewmew/float v0.0.0-20191226120903-16bbe2fdd85e h1:KCD7E/8LKwDsC5ymlEWJ3xCiSPaCywrS/psToBMOBH4=
 github.com/mewmew/float v0.0.0-20191226120903-16bbe2fdd85e/go.mod h1:O+xb+8ycBNHzJicFVs7GRWtruD4tVZI0huVnw5TM01E=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/ir/enum/callingconv_string.go
+++ b/ir/enum/callingconv_string.go
@@ -21,6 +21,7 @@ func _() {
 	_ = x[CallingConvSwift-16]
 	_ = x[CallingConvCXXFastTLS-17]
 	_ = x[CallingConvTail-18]
+	_ = x[CallingConvCFGuardCheck-19]
 	_ = x[CallingConvX86StdCall-64]
 	_ = x[CallingConvX86FastCall-65]
 	_ = x[CallingConvARM_APCS-66]
@@ -58,14 +59,14 @@ func _() {
 
 const (
 	_CallingConv_name_0 = "noneccc"
-	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcc"
+	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcccfguard_checkcc"
 	_CallingConv_name_2 = "x86_stdcallccx86_fastcallccarm_apcsccarm_aapcsccarm_aapcs_vfpccmsp430_intrccx86_thiscallccptx_kernelptx_device"
 	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcsaarch64_sve_vector_pcs"
 )
 
 var (
 	_CallingConv_index_0 = [...]uint8{0, 4, 7}
-	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97}
+	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97, 112}
 	_CallingConv_index_2 = [...]uint8{0, 13, 27, 37, 48, 63, 76, 90, 100, 110}
 	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233, 255}
 )
@@ -74,7 +75,7 @@ func (i CallingConv) String() string {
 	switch {
 	case i <= 1:
 		return _CallingConv_name_0[_CallingConv_index_0[i]:_CallingConv_index_0[i+1]]
-	case 8 <= i && i <= 18:
+	case 8 <= i && i <= 19:
 		i -= 8
 		return _CallingConv_name_1[_CallingConv_index_1[i]:_CallingConv_index_1[i+1]]
 	case 64 <= i && i <= 72:

--- a/ir/enum/callingconv_string.go
+++ b/ir/enum/callingconv_string.go
@@ -20,6 +20,7 @@ func _() {
 	_ = x[CallingConvPreserveAll-15]
 	_ = x[CallingConvSwift-16]
 	_ = x[CallingConvCXXFastTLS-17]
+	_ = x[CallingConvTail-18]
 	_ = x[CallingConvX86StdCall-64]
 	_ = x[CallingConvX86FastCall-65]
 	_ = x[CallingConvARM_APCS-66]
@@ -52,33 +53,34 @@ func _() {
 	_ = x[CallingConvAMDGPU_LS-95]
 	_ = x[CallingConvAMDGPU_ES-96]
 	_ = x[CallingConvAArch64VectorCall-97]
+	_ = x[CallingConvAArch64SVEVectorCall-98]
 }
 
 const (
 	_CallingConv_name_0 = "noneccc"
-	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscc"
+	_CallingConv_name_1 = "fastcccoldccghccccc 11webkit_jsccanyregccpreserve_mostccpreserve_allccswiftcccxx_fast_tlscctailcc"
 	_CallingConv_name_2 = "x86_stdcallccx86_fastcallccarm_apcsccarm_aapcsccarm_aapcs_vfpccmsp430_intrccx86_thiscallccptx_kernelptx_device"
-	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcs"
+	_CallingConv_name_3 = "spir_funcspir_kernelintel_ocl_biccx86_64_sysvccwin64ccx86_vectorcallcchhvmcchhvm_cccx86_intrccavr_intrccavr_signalcccc 86amdgpu_vsamdgpu_gsamdgpu_psamdgpu_csamdgpu_kernelx86_regcallccamdgpu_hscc 94amdgpu_lsamdgpu_esaarch64_vector_pcsaarch64_sve_vector_pcs"
 )
 
 var (
 	_CallingConv_index_0 = [...]uint8{0, 4, 7}
-	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91}
+	_CallingConv_index_1 = [...]uint8{0, 6, 12, 17, 22, 33, 41, 56, 70, 77, 91, 97}
 	_CallingConv_index_2 = [...]uint8{0, 13, 27, 37, 48, 63, 76, 90, 100, 110}
-	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233}
+	_CallingConv_index_3 = [...]uint8{0, 9, 20, 34, 47, 54, 70, 76, 84, 94, 104, 116, 121, 130, 139, 148, 157, 170, 183, 192, 197, 206, 215, 233, 255}
 )
 
 func (i CallingConv) String() string {
 	switch {
 	case i <= 1:
 		return _CallingConv_name_0[_CallingConv_index_0[i]:_CallingConv_index_0[i+1]]
-	case 8 <= i && i <= 17:
+	case 8 <= i && i <= 18:
 		i -= 8
 		return _CallingConv_name_1[_CallingConv_index_1[i]:_CallingConv_index_1[i+1]]
 	case 64 <= i && i <= 72:
 		i -= 64
 		return _CallingConv_name_2[_CallingConv_index_2[i]:_CallingConv_index_2[i+1]]
-	case 75 <= i && i <= 97:
+	case 75 <= i && i <= 98:
 		i -= 75
 		return _CallingConv_name_3[_CallingConv_index_3[i]:_CallingConv_index_3[i+1]]
 	default:

--- a/ir/enum/enum.go
+++ b/ir/enum/enum.go
@@ -63,6 +63,7 @@ const (
 	CallingConvPreserveAll  CallingConv = 15 // preserve_allcc
 	CallingConvSwift        CallingConv = 16 // swiftcc
 	CallingConvCXXFastTLS   CallingConv = 17 // cxx_fast_tlscc
+	CallingConvTail         CallingConv = 18 // tailcc
 
 	// Start of target-specific calling conventions.
 	CallingConvFirstTarget = CallingConvX86StdCall
@@ -77,29 +78,30 @@ const (
 	CallingConvPTXKernel     CallingConv = 71 // ptx_kernel
 	CallingConvPTXDevice     CallingConv = 72 // ptx_device
 
-	CallingConvSPIRFunc          CallingConv = 75 // spir_func
-	CallingConvSPIRKernel        CallingConv = 76 // spir_kernel
-	CallingConvIntelOCL_BI       CallingConv = 77 // intel_ocl_bicc
-	CallingConvX86_64SysV        CallingConv = 78 // x86_64_sysvcc
-	CallingConvWin64             CallingConv = 79 // win64cc
-	CallingConvX86VectorCall     CallingConv = 80 // x86_vectorcallcc
-	CallingConvHHVM              CallingConv = 81 // hhvmcc
-	CallingConvHHVM_C            CallingConv = 82 // hhvm_ccc
-	CallingConvX86Intr           CallingConv = 83 // x86_intrcc
-	CallingConvAVRIntr           CallingConv = 84 // avr_intrcc
-	CallingConvAVRSignal         CallingConv = 85 // avr_signalcc
-	CallingConvAVRBuiltin        CallingConv = 86 // cc 86
-	CallingConvAMDGPU_VS         CallingConv = 87 // amdgpu_vs
-	CallingConvAMDGPU_GS         CallingConv = 88 // amdgpu_gs
-	CallingConvAMDGPU_PS         CallingConv = 89 // amdgpu_ps
-	CallingConvAMDGPU_CS         CallingConv = 90 // amdgpu_cs
-	CallingConvAMDGPUKernel      CallingConv = 91 // amdgpu_kernel
-	CallingConvX86RegCall        CallingConv = 92 // x86_regcallcc
-	CallingConvAMDGPU_HS         CallingConv = 93 // amdgpu_hs
-	CallingConvMSP430Builtin     CallingConv = 94 // cc 94
-	CallingConvAMDGPU_LS         CallingConv = 95 // amdgpu_ls
-	CallingConvAMDGPU_ES         CallingConv = 96 // amdgpu_es
-	CallingConvAArch64VectorCall CallingConv = 97 // aarch64_vector_pcs
+	CallingConvSPIRFunc             CallingConv = 75 // spir_func
+	CallingConvSPIRKernel           CallingConv = 76 // spir_kernel
+	CallingConvIntelOCL_BI          CallingConv = 77 // intel_ocl_bicc
+	CallingConvX86_64SysV           CallingConv = 78 // x86_64_sysvcc
+	CallingConvWin64                CallingConv = 79 // win64cc
+	CallingConvX86VectorCall        CallingConv = 80 // x86_vectorcallcc
+	CallingConvHHVM                 CallingConv = 81 // hhvmcc
+	CallingConvHHVM_C               CallingConv = 82 // hhvm_ccc
+	CallingConvX86Intr              CallingConv = 83 // x86_intrcc
+	CallingConvAVRIntr              CallingConv = 84 // avr_intrcc
+	CallingConvAVRSignal            CallingConv = 85 // avr_signalcc
+	CallingConvAVRBuiltin           CallingConv = 86 // cc 86
+	CallingConvAMDGPU_VS            CallingConv = 87 // amdgpu_vs
+	CallingConvAMDGPU_GS            CallingConv = 88 // amdgpu_gs
+	CallingConvAMDGPU_PS            CallingConv = 89 // amdgpu_ps
+	CallingConvAMDGPU_CS            CallingConv = 90 // amdgpu_cs
+	CallingConvAMDGPUKernel         CallingConv = 91 // amdgpu_kernel
+	CallingConvX86RegCall           CallingConv = 92 // x86_regcallcc
+	CallingConvAMDGPU_HS            CallingConv = 93 // amdgpu_hs
+	CallingConvMSP430Builtin        CallingConv = 94 // cc 94
+	CallingConvAMDGPU_LS            CallingConv = 95 // amdgpu_ls
+	CallingConvAMDGPU_ES            CallingConv = 96 // amdgpu_es
+	CallingConvAArch64VectorCall    CallingConv = 97 // aarch64_vector_pcs
+	CallingConvAArch64SVEVectorCall CallingConv = 98 // aarch64_sve_vector_pcs
 )
 
 //go:generate stringer -linecomment -type ChecksumKind

--- a/ir/enum/enum.go
+++ b/ir/enum/enum.go
@@ -64,6 +64,7 @@ const (
 	CallingConvSwift        CallingConv = 16 // swiftcc
 	CallingConvCXXFastTLS   CallingConv = 17 // cxx_fast_tlscc
 	CallingConvTail         CallingConv = 18 // tailcc
+	CallingConvCFGuardCheck CallingConv = 19 // cfguard_checkcc
 
 	// Start of target-specific calling conventions.
 	CallingConvFirstTarget = CallingConvX86StdCall


### PR DESCRIPTION
- [x] update ll in go.mod

The only weird thing is I have no idea where `cfguard_checkcc` defined in [C++ header](https://llvm.org/doxygen/namespacellvm_1_1CallingConv.html). It should up to date v10 but no `guard`, `check` or `cf` word existed.