### PR TITLE
minimal example

### DIFF
--- a/ir/experience.go
+++ b/ir/experience.go
@@ -1,0 +1,24 @@
+package ir
+
+import (
+	"github.com/llir/llvm/ir/types"
+)
+
+type Value interface {
+	isValue()
+}
+
+type LocalIdent2 struct {
+	Value
+	Name string
+	types.Type
+}
+
+type Inst interface {
+	isInst()
+}
+
+type InstAdd2 struct {
+	LocalIdent2
+	X, Y Value
+}

--- a/ir/experience_test.go
+++ b/ir/experience_test.go
@@ -1,0 +1,22 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/llir/llvm/ir/types"
+)
+
+func TestSample(t *testing.T) {
+	x := &LocalIdent2{Name: "X", Type: types.I32}
+
+	inst := &InstAdd2{
+		LocalIdent2: LocalIdent2{Name: "X", Type: types.I32},
+		X:           x,
+		Y:           x,
+	}
+
+	inst.Name = "Y"
+
+	println(x.Name)
+	println(inst.Name)
+}


### PR DESCRIPTION
result:
```
X
Y
```

and we can update type cache without suffering by infinite loop